### PR TITLE
Fix Color Ramp Styling for Implementation Models

### DIFF
--- a/src/cplus_plugin/gui/implementation_model_editor_dialog.py
+++ b/src/cplus_plugin/gui/implementation_model_editor_dialog.py
@@ -54,7 +54,8 @@ class ImplementationModelEditorDialog(QtWidgets.QDialog, WidgetUi):
         self.style_btn.setSymbolType(Qgis.SymbolType.Fill)
 
         self.btn_color_ramp.setShowNull(False)
-        self.btn_color_ramp.setRandomColorRamp()
+        self.btn_color_ramp.setToNull()
+        self.btn_color_ramp.setShowGradientOnly(True)
         self.btn_color_ramp.setColorRampDialogTitle(
             self.tr("Set Color Ramp for Output Implementation Model")
         )
@@ -207,8 +208,7 @@ class ImplementationModelEditorDialog(QtWidgets.QDialog, WidgetUi):
             self._show_warning_message(msg)
             status = False
 
-        output_model_color_ramp = self.btn_color_ramp.colorRamp()
-        if output_model_color_ramp is None:
+        if self.btn_color_ramp.colorRamp() is None or self.btn_color_ramp.isNull():
             msg = tr("No color ramp defined for the output model layer.")
             self._show_warning_message(msg)
             status = False

--- a/src/cplus_plugin/gui/implementation_model_editor_dialog.py
+++ b/src/cplus_plugin/gui/implementation_model_editor_dialog.py
@@ -64,12 +64,7 @@ class ImplementationModelEditorDialog(QtWidgets.QDialog, WidgetUi):
         start_color = QtGui.QColor.fromRgb(QtCore.QRandomGenerator.global_().generate())
         stop_color = QtGui.QColor.fromRgb(QtCore.QRandomGenerator.global_().generate())
         self.style_btn.setColor(start_color)
-        self.btn_color_ramp.setColorRamp(
-            QgsGradientColorRamp(
-                start_color,
-                stop_color
-            )
-        )
+        self.btn_color_ramp.setColorRamp(QgsGradientColorRamp(start_color, stop_color))
 
         self.buttonBox.accepted.connect(self._on_accepted)
         self.btn_select_file.clicked.connect(self._on_select_file)

--- a/src/cplus_plugin/gui/implementation_model_editor_dialog.py
+++ b/src/cplus_plugin/gui/implementation_model_editor_dialog.py
@@ -10,14 +10,14 @@ import uuid
 from qgis.core import (
     Qgis,
     QgsColorRamp,
-    QgsFillSymbol,
     QgsFillSymbolLayer,
+    QgsGradientColorRamp,
     QgsMapLayerProxyModel,
     QgsRasterLayer,
 )
 from qgis.gui import QgsGui, QgsMessageBar
 
-from qgis.PyQt import QtGui, QtWidgets
+from qgis.PyQt import QtCore, QtGui, QtWidgets
 
 from qgis.PyQt.uic import loadUiType
 
@@ -58,6 +58,17 @@ class ImplementationModelEditorDialog(QtWidgets.QDialog, WidgetUi):
         self.btn_color_ramp.setShowGradientOnly(True)
         self.btn_color_ramp.setColorRampDialogTitle(
             self.tr("Set Color Ramp for Output Implementation Model")
+        )
+
+        # Default colors
+        start_color = QtGui.QColor.fromRgb(QtCore.QRandomGenerator.global_().generate())
+        stop_color = QtGui.QColor.fromRgb(QtCore.QRandomGenerator.global_().generate())
+        self.style_btn.setColor(start_color)
+        self.btn_color_ramp.setColorRamp(
+            QgsGradientColorRamp(
+                start_color,
+                stop_color
+            )
         )
 
         self.buttonBox.accepted.connect(self._on_accepted)

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -31,21 +31,16 @@ from qgis.core import (
     QgsFeedback,
     QgsGeometry,
     QgsProject,
-    QgsProcessing,
     QgsProcessingAlgRunnerTask,
     QgsProcessingContext,
     QgsProcessingFeedback,
-    QgsRandomColorRamp,
     QgsRasterLayer,
     QgsRectangle,
     QgsTask,
     QgsWkbTypes,
     QgsColorRampShader,
     QgsSingleBandPseudoColorRenderer,
-    QgsRasterShader,
     QgsPalettedRasterRenderer,
-    QgsStyle,
-    QgsRasterMinMaxOrigin,
 )
 
 from qgis.gui import (

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -35,6 +35,7 @@ from qgis.core import (
     QgsProcessingAlgRunnerTask,
     QgsProcessingContext,
     QgsProcessingFeedback,
+    QgsRandomColorRamp,
     QgsRasterLayer,
     QgsRectangle,
     QgsTask,

--- a/src/cplus_plugin/models/base.py
+++ b/src/cplus_plugin/models/base.py
@@ -522,7 +522,7 @@ class ImplementationModel(LayerModelComponent):
             return None
 
         ramp_info = model_layer_info.get(COLOR_RAMP_PROPERTIES_ATTRIBUTE, None)
-        if ramp_info is None or len(ramp_info) == 0:
+        if ramp_info is None:
             return None
 
         ramp_type = model_layer_info.get(COLOR_RAMP_TYPE_ATTRIBUTE, None)


### PR DESCRIPTION
`QgsSingleBandPseudoColorRenderer` does not support a random color ramp hence this option has been removed when creating a new (custom) or editing an existing (default) implementation model using the editor dialog.