### PR TITLE
Use QGIS 3.34 LTR for all building workflows

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -12,7 +12,7 @@ jobs:
   build-docs:
     runs-on: ubuntu-20.04
     container:
-      image: qgis/qgis:release-3_30
+      image: qgis/qgis:release-3_34
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           - release-3_22
           - release-3_28
           - release-3_30
-          - release-3.34
+          - release-3_34
         os: [ubuntu-22.04]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
           - release-3_22
           - release-3_28
           - release-3_30
-          - release-3_34
         os: [ubuntu-22.04]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,10 @@ jobs:
       fail-fast: false
       matrix:
         qgis_version_tag:
-          - release-3_16
           - release-3_22
           - release-3_28
           - release-3_30
-          - final-3_32_2
+          - release-3.34
         os: [ubuntu-22.04]
 
     steps:

--- a/.github/workflows/pr_package.yml
+++ b/.github/workflows/pr_package.yml
@@ -14,7 +14,7 @@ jobs:
   create-package:
     runs-on: ubuntu-22.04
     container:
-      image: qgis/qgis:release-3_30
+      image: qgis/qgis:release-3_34
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/push_package.yml
+++ b/.github/workflows/push_package.yml
@@ -9,7 +9,7 @@ jobs:
   create-package:
     runs-on: ubuntu-22.04
     container:
-      image: qgis/qgis:release-3_30
+      image: qgis/qgis:release-3_34
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
   create-release:
     runs-on: ubuntu-22.04
     container:
-      image: qgis/qgis:release-3_30
+      image: qgis/qgis:release-3_34
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/docs/developer/api/core/api_settings.md
+++ b/docs/developer/api/core/api_settings.md
@@ -1,6 +1,6 @@
 # Settings
 
-::: src.cplus_plugin.settings
+::: src.cplus_plugin.gui.settings
     handler: python
     options:
         docstring_style: sphinx


### PR DESCRIPTION
Changes to make PR, push and merging workflow to test against QGIS Long term release version (3.34)