### PR TITLE
Update Minimum QGIS Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 | Plugin version(s)                                                                                                                                                                                                          | Minimum QGIS version | Maximum QGIS version |
 |----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------|------|
-| ![GitHub Epic 1 Release)](https://img.shields.io/github/v/release/ConservationInternational/cplus-plugin?logo=semanticrelease&label=latest-release)<br> ![](https://img.shields.io/badge/stable_version-v0.2.0dev-blue?logo=semanticrelease) | 3.22                 | 3.99 |
+| ![GitHub Epic 1 Release)](https://img.shields.io/github/v/release/ConservationInternational/cplus-plugin?logo=semanticrelease&label=latest-release)<br> ![](https://img.shields.io/badge/stable_version-v0.2.0dev-blue?logo=semanticrelease) | 3.32                 | 3.99 |
 
 
 ### ⚙️ Installation

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name" : "CPLUS plugin",
-    "qgisMinimumVersion": 3.22,
+    "qgisMinimumVersion": 3.32,
     "qgisMaximumVersion": 3.99,
     "icon": "icon.svg",
     "experimental": false,


### PR DESCRIPTION
Update the minimum QGIS version to 3.32 to leverage on [this](https://api.qgis.org/api/3.32/classQgsOptionsWidgetFactory.html#a1c6a19367db36758fc19ba11bca2289d) API feature that allows for grouping of option items in a tree view using the `path()`.