### PR TITLE
Workaround for CPlus Options

### DIFF
--- a/src/cplus_plugin/definitions/defaults.py
+++ b/src/cplus_plugin/definitions/defaults.py
@@ -25,6 +25,7 @@ ABOUT_DOCUMENTATION_SITE = (
 REPORT_DOCUMENTATION = "https://conservationinternational.github.io/cplus-plugin/user/guide/#report-generating"
 
 OPTIONS_TITLE = "CPLUS"  # Title in the QGIS settings
+GENERAL_OPTIONS_TITLE = "General"
 REPORT_OPTIONS_TITLE = "Reporting"
 LOG_OPTIONS_TITLE = "Logs"
 ICON_PATH = ":/plugins/cplus_plugin/icon.svg"

--- a/src/cplus_plugin/gui/settings/cplus_options.py
+++ b/src/cplus_plugin/gui/settings/cplus_options.py
@@ -33,11 +33,11 @@ from ...conf import (
 )
 from ...definitions.constants import CPLUS_OPTIONS_KEY
 from ...definitions.defaults import (
-    OPTIONS_TITLE,
+    GENERAL_OPTIONS_TITLE,
     ICON_PATH,
-    DEFAULT_LOGO_PATH,
+    OPTIONS_TITLE,
 )
-from ...utils import FileUtils, tr
+from ...utils import FileUtils, log, tr
 
 
 Ui_DlgSettings, _ = uic.loadUiType(
@@ -301,7 +301,7 @@ class CplusSettings(Ui_DlgSettings, QgsOptionsPageWidget):
 class CplusOptionsFactory(QgsOptionsWidgetFactory):
     """Options factory initializes the CPLUS settings.
 
-    Class which creates the widget requied for the CPLUS settings.
+    Class which creates the widget required for the CPLUS settings.
     QgsOptionsWidgetFactory is used to accomplish this.
     """
 
@@ -309,8 +309,17 @@ class CplusOptionsFactory(QgsOptionsWidgetFactory):
         """QGIS CPLUS Plugin Settings factory."""
         super().__init__()
 
-        self.setTitle(OPTIONS_TITLE)
-        self.setKey(CPLUS_OPTIONS_KEY)
+        # Check version for API compatibility for managing items in
+        # options tree view.
+        version = qgis.core.Qgis.versionInt()
+        log(str(version))
+        if version < 33200:
+            log("Old version")
+            self.setTitle(GENERAL_OPTIONS_TITLE)
+        else:
+            log("New version")
+            self.setTitle(OPTIONS_TITLE)
+            self.setKey(CPLUS_OPTIONS_KEY)
 
     def icon(self) -> QIcon:
         """Returns the icon which will be used for the CPLUS options tab.
@@ -320,6 +329,22 @@ class CplusOptionsFactory(QgsOptionsWidgetFactory):
         """
 
         return QIcon(ICON_PATH)
+
+    def path(self) -> typing.List[str]:
+        """
+        Returns the path to place the widget page at.
+
+        This instructs the registry to place the log options tab under the
+        main CPLUS settings.
+
+        :returns: Path name of the main CPLUS settings.
+        :rtype: list
+        """
+        version = qgis.core.Qgis.versionInt()
+        if version < 33200:
+            return [OPTIONS_TITLE]
+
+        return list()
 
     def createWidget(self, parent: QWidget) -> CplusSettings:
         """Creates a widget for CPLUS settings.

--- a/src/cplus_plugin/gui/settings/log_options.py
+++ b/src/cplus_plugin/gui/settings/log_options.py
@@ -5,6 +5,8 @@
 import os
 import typing
 
+import qgis.core
+
 from qgis.gui import QgsFileWidget, QgsOptionsPageWidget
 from qgis.gui import QgsOptionsWidgetFactory
 from qgis.PyQt import uic
@@ -22,7 +24,11 @@ from ...conf import (
     Settings,
 )
 from ...definitions.constants import CPLUS_OPTIONS_KEY, LOG_OPTIONS_KEY
-from ...definitions.defaults import LOG_OPTIONS_TITLE, LOG_SETTINGS_ICON_PATH
+from ...definitions.defaults import (
+    LOG_OPTIONS_TITLE,
+    LOG_SETTINGS_ICON_PATH,
+    OPTIONS_TITLE,
+)
 from ...utils import FileUtils, tr
 
 
@@ -49,8 +55,13 @@ class LogOptionsFactory(QgsOptionsWidgetFactory):
     def __init__(self) -> None:
         super().__init__()
 
+        # Check version for API compatibility for managing items in
+        # options tree view.
+        version = qgis.core.Qgis.versionInt()
+        if version >= 33200:
+            self.setKey(LOG_OPTIONS_KEY)
+
         self.setTitle(LOG_OPTIONS_TITLE)
-        self.setKey(LOG_OPTIONS_KEY)
 
     def icon(self) -> QIcon:
         """Returns the icon which will be used for the log settings item.
@@ -70,6 +81,10 @@ class LogOptionsFactory(QgsOptionsWidgetFactory):
         :returns: Path name of the main CPLUS settings.
         :rtype: list
         """
+        version = qgis.core.Qgis.versionInt()
+        if version < 33200:
+            return [OPTIONS_TITLE]
+
         return [CPLUS_OPTIONS_KEY]
 
     def createWidget(self, parent: QWidget) -> LogSettingsWidget:

--- a/src/cplus_plugin/gui/settings/report_options.py
+++ b/src/cplus_plugin/gui/settings/report_options.py
@@ -5,6 +5,8 @@
 import os
 import typing
 
+import qgis.core
+
 from qgis.gui import QgsFileWidget, QgsMessageBar, QgsOptionsPageWidget
 from qgis.gui import QgsOptionsWidgetFactory
 from qgis.PyQt import uic
@@ -24,6 +26,7 @@ from ...conf import (
 from ...definitions.constants import CPLUS_OPTIONS_KEY, REPORTS_OPTIONS_KEY
 from ...definitions.defaults import (
     DEFAULT_LOGO_PATH,
+    OPTIONS_TITLE,
     REPORT_OPTIONS_TITLE,
     REPORT_SETTINGS_ICON_PATH,
 )
@@ -251,8 +254,13 @@ class ReportOptionsFactory(QgsOptionsWidgetFactory):
     def __init__(self) -> None:
         super().__init__()
 
+        # Check version for API compatibility for managing items in
+        # options tree view.
+        version = qgis.core.Qgis.versionInt()
+        if version >= 33200:
+            self.setKey(REPORTS_OPTIONS_KEY)
+
         self.setTitle(tr(REPORT_OPTIONS_TITLE))
-        self.setKey(REPORTS_OPTIONS_KEY)
 
     def icon(self) -> QIcon:
         """Returns the icon which will be used for the report settings item.
@@ -272,6 +280,10 @@ class ReportOptionsFactory(QgsOptionsWidgetFactory):
         :returns: Path name of the main CPLUS settings.
         :rtype: list
         """
+        version = qgis.core.Qgis.versionInt()
+        if version < 33200:
+            return [OPTIONS_TITLE]
+
         return [CPLUS_OPTIONS_KEY]
 
     def createWidget(self, parent: QWidget) -> ReportSettingsWidget:

--- a/src/cplus_plugin/ui/report_settings.ui
+++ b/src/cplus_plugin/ui/report_settings.ui
@@ -119,6 +119,9 @@
           <height>100</height>
          </size>
         </property>
+        <property name="placeholderText">
+         <string>Please enter the stakeholder name and a brief description of the relationship separated by a dash i.e. stakeholder name - relstionship description. Each entry should be in a new line.</string>
+        </property>
        </widget>
       </item>
       <item row="14" column="2">
@@ -128,6 +131,9 @@
           <width>16777215</width>
           <height>100</height>
          </size>
+        </property>
+        <property name="placeholderText">
+         <string>Please enter the cultural consideration and a brief description separated by a dash i.e. cultural consideration - description. Each entry should be in a new line.</string>
         </property>
        </widget>
       </item>
@@ -182,6 +188,9 @@
           <width>16777215</width>
           <height>100</height>
          </size>
+        </property>
+        <property name="placeholderText">
+         <string>Please enter the cultural policy and a brief description separated by a dash i.e. cultural policy - description. Each entry should be in a new line.</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
This PR incorporates a workaround for arranging CPlus options' categories based on the QGIS version. This is to address API changes introduced in QGIS v3.32.

For QGIS versions below 3.32, the options are grouped as shown below:

![image](https://github.com/ConservationInternational/cplus-plugin/assets/3840267/07a27042-33f8-4323-83bd-396817fd1ee1)

For QGIS v3.32 and above, the options are grouped as shown below:

![image](https://github.com/ConservationInternational/cplus-plugin/assets/3840267/1a501fb2-ff25-46f3-807d-d284ef93220e)
