### PR TITLE
Mask-out option implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@
 
 * Available and supported in all the QGIS 3.x versions
 
-| Plugin version(s)                                                                                                                                                                                                          | Minimum QGIS version | Maximum QGIS version |
-|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------|------|
-| ![GitHub Epic 1 Release)](https://img.shields.io/github/v/release/ConservationInternational/cplus-plugin?logo=semanticrelease&label=latest-release)<br> ![](https://img.shields.io/badge/stable_version-v0.2.0dev-blue?logo=semanticrelease) | 3.22                 | 3.99 |
+| Plugin version(s)                                                                                                                                                                                                                         | Minimum QGIS version | Maximum QGIS version |
+|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------|------|
+| ![GitHub Epic 1 Release)](https://img.shields.io/github/v/release/ConservationInternational/cplus-plugin?logo=semanticrelease&label=latest-release)<br> ![](https://img.shields.io/badge/stable_version-v0.0.1-blue?logo=semanticrelease) | 3.22                 | 3.99 |
 
 
 ### ⚙️ Installation

--- a/src/cplus_plugin/conf.py
+++ b/src/cplus_plugin/conf.py
@@ -163,6 +163,9 @@ class Settings(enum.Enum):
     SIEVE_THRESHOLD = "sieve_threshold"
     SIEVE_MASK_PATH = "mask_path"
 
+    # Mask layer
+    MASK_LAYERS_PATHS = "mask_layers_paths"
+
 
 class SettingsManager(QtCore.QObject):
     """Manages saving/loading settings for the plugin in QgsSettings."""

--- a/src/cplus_plugin/ui/cplus_settings.ui
+++ b/src/cplus_plugin/ui/cplus_settings.ui
@@ -250,6 +250,77 @@
         </widget>
        </item>
        <item>
+        <widget class="QgsCollapsibleGroupBox" name="mask_layers_box">
+         <property name="title">
+          <string>Mask layers</string>
+         </property>
+         <property name="collapsed">
+          <bool>false</bool>
+         </property>
+         <property name="saveCheckedState">
+          <bool>false</bool>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_3">
+          <item row="0" column="0">
+           <spacer name="horizontalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>367</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="0" column="1">
+           <widget class="QToolButton" name="btn_add_mask">
+            <property name="toolTip">
+             <string>Add carbon layer</string>
+            </property>
+            <property name="text">
+             <string>...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QToolButton" name="btn_edit_mask">
+            <property name="toolTip">
+             <string>Edit carbon layer</string>
+            </property>
+            <property name="text">
+             <string>...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="3">
+           <widget class="QToolButton" name="btn_delete_mask">
+            <property name="toolTip">
+             <string>Remove carbon layer</string>
+            </property>
+            <property name="text">
+             <string>...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0" colspan="4">
+           <widget class="QListView" name="lst_mask_layers">
+            <property name="editTriggers">
+             <set>QAbstractItemView::NoEditTriggers</set>
+            </property>
+            <property name="selectionMode">
+             <enum>QAbstractItemView::ExtendedSelection</enum>
+            </property>
+            <property name="selectionBehavior">
+             <enum>QAbstractItemView::SelectRows</enum>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <spacer name="scroll_area_vspacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/src/cplus_plugin/ui/cplus_settings.ui
+++ b/src/cplus_plugin/ui/cplus_settings.ui
@@ -305,17 +305,7 @@
            </widget>
           </item>
           <item row="1" column="0" colspan="4">
-           <widget class="QListView" name="lst_mask_layers">
-            <property name="editTriggers">
-             <set>QAbstractItemView::NoEditTriggers</set>
-            </property>
-            <property name="selectionMode">
-             <enum>QAbstractItemView::ExtendedSelection</enum>
-            </property>
-            <property name="selectionBehavior">
-             <enum>QAbstractItemView::SelectRows</enum>
-            </property>
-           </widget>
+           <widget class="QListWidget" name="lst_mask_layers"/>
           </item>
          </layout>
         </widget>


### PR DESCRIPTION
Fixes https://github.com/ConservationInternational/cplus-plugin/issues/319

Includes mask feature for activities layers, with new settings gui control components users can now add mask layers that will be used to mask activities layers when running scenario analysis.

The mask layers should be vector layers with Polygon layer type, processing will skip masking if any other layer type is provided for use.

The main processing algorithm used for masking is [`gdal:cliprasterbymasklayer` ](https://docs.qgis.org/3.34/en/docs/user_manual/processing_algs/gdal/rasterextraction.html#clip-raster-by-mask-layer)