### PR TITLE
Tracking scenario inputs/outputs

### DIFF
--- a/src/cplus_plugin/definitions/defaults.py
+++ b/src/cplus_plugin/definitions/defaults.py
@@ -13,6 +13,17 @@ PILOT_AREA_EXTENT = {
     "coordinates": [30.743498637, 32.069186664, -25.201606226, -23.960197335],
 }
 
+PLUGIN_MESSAGE_LOG_TAB = "qgis_cplus"
+SCENARIO_LOG_FILE_NAME = "processing.log"
+
+QGIS_MESSAGE_LEVEL_DICT = {
+    0: "INFO",
+    1: "WARNING",
+    2: "CRITICAL",
+    3: "SUCCESS",
+    4: "NOLEVEL",
+}
+
 DEFAULT_CRS_ID = 4326
 
 DOCUMENTATION_SITE = "https://conservationinternational.github.io/cplus-plugin"

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -150,6 +150,16 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
 
         self.analysis_finished.connect(self.post_analysis)
 
+        # Log
+        QgsApplication.messageLog().messageReceived.connect(
+            self.on_log_message_received
+        )
+
+    def on_log_message_received(self, message, tag, level):
+        if tag == "qgis_cplus":
+            message = f"{self.log_text_box.toPlainText()}{message}"
+            self.log_text_box.setPlainText(f"{message} \n")
+
     def prepare_input(self):
         """Initializes plugin input widgets"""
         self.prepare_extent_box()

--- a/src/cplus_plugin/ui/qgis_cplus_main_dockwidget.ui
+++ b/src/cplus_plugin/ui/qgis_cplus_main_dockwidget.ui
@@ -87,7 +87,7 @@
     <item>
      <widget class="QTabWidget" name="tab_widget">
       <property name="currentIndex">
-       <number>0</number>
+       <number>2</number>
       </property>
       <widget class="QWidget" name="step_3">
        <attribute name="title">
@@ -448,6 +448,27 @@
              <string>Run Scenario</string>
             </property>
            </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="log">
+       <attribute name="title">
+        <string>Log</string>
+       </attribute>
+       <layout class="QGridLayout" name="gridLayout_3">
+        <item row="0" column="0">
+         <layout class="QGridLayout" name="gridLayout_2">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Processing Log</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QPlainTextEdit" name="log_text_box"/>
           </item>
          </layout>
         </item>

--- a/src/cplus_plugin/ui/qgis_cplus_main_dockwidget.ui
+++ b/src/cplus_plugin/ui/qgis_cplus_main_dockwidget.ui
@@ -87,7 +87,7 @@
     <item>
      <widget class="QTabWidget" name="tab_widget">
       <property name="currentIndex">
-       <number>2</number>
+       <number>0</number>
       </property>
       <widget class="QWidget" name="step_3">
        <attribute name="title">
@@ -278,7 +278,7 @@
             </property>
             <property name="icon">
              <iconset>
-              <normaloff>../../../../../../../resources/cplus_right_arrow.svg</normaloff>../../../../../../../resources/cplus_right_arrow.svg</iconset>
+              <normaloff>../../../../../../../../../../../resources/cplus_right_arrow.svg</normaloff>../../../../../../../../../../../resources/cplus_right_arrow.svg</iconset>
             </property>
            </widget>
           </item>
@@ -292,7 +292,7 @@
             </property>
             <property name="icon">
              <iconset>
-              <normaloff>../../../../../../../resources/cplus_left_arrow.svg</normaloff>../../../../../../../resources/cplus_left_arrow.svg</iconset>
+              <normaloff>../../../../../../../../../../../resources/cplus_left_arrow.svg</normaloff>../../../../../../../../../../../resources/cplus_left_arrow.svg</iconset>
             </property>
            </widget>
           </item>

--- a/src/cplus_plugin/utils.py
+++ b/src/cplus_plugin/utils.py
@@ -82,6 +82,11 @@ def log(
     )
 
 
+def write_to_file(message, file_path):
+    with open(file_path, "w+") as f:
+        f.write(message)
+
+
 def open_documentation(url=None):
     """Opens documentation website in the default browser
 


### PR DESCRIPTION
Fixes https://github.com/ConservationInternational/cplus-plugin/issues/323

Adds new 'Log' tab in the plugin main dock that tracks all the plugin related message logs, these changes also include functionality that automatically saves the scenario analysis logs into a processing log file `processing.log` that is located in the scenario analysis directory.
