### PR TITLE
Scenario outputs selections

### DIFF
--- a/src/cplus_plugin/conf.py
+++ b/src/cplus_plugin/conf.py
@@ -166,6 +166,13 @@ class Settings(enum.Enum):
     # Mask layer
     MASK_LAYERS_PATHS = "mask_layers_paths"
 
+    # Outputs options
+    NCS_WITH_CARBON = "ncs_with_carbon"
+    LANDUSE_PROJECT = "landuse_project"
+    LANDUSE_NORMALIZED = "landuse_normalized"
+    LANDUSE_WEIGHTED = "landuse_weighted"
+    HIGHEST_POSITION = "highest_position"
+
 
 class SettingsManager(QtCore.QObject):
     """Manages saving/loading settings for the plugin in QgsSettings."""

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -146,6 +146,15 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
         self.priority_groups_widgets = {}
         self.pwl_item_flags = None
 
+        # Step 4
+        self.ncs_with_carbon.toggled.connect(self.outputs_options_changed)
+        self.landuse_project.toggled.connect(self.outputs_options_changed)
+        self.landuse_normalized.toggled.connect(self.outputs_options_changed)
+        self.landuse_weighted.toggled.connect(self.outputs_options_changed)
+        self.highest_position.toggled.connect(self.outputs_options_changed)
+
+        self.load_layer_options()
+
         self.initialize_priority_layers()
 
         self.position_feedback = QgsProcessingFeedback()
@@ -160,10 +169,65 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
             self.on_log_message_received
         )
 
+    def outputs_options_changed(self):
+        """
+        Handles selected outputs changes
+        """
+
+        settings_manager.set_value(
+            Settings.NCS_WITH_CARBON, self.ncs_with_carbon.isChecked()
+        )
+        settings_manager.set_value(
+            Settings.LANDUSE_PROJECT, self.landuse_project.isChecked()
+        )
+        settings_manager.set_value(
+            Settings.LANDUSE_NORMALIZED, self.landuse_normalized.isChecked()
+        )
+        settings_manager.set_value(
+            Settings.LANDUSE_WEIGHTED, self.landuse_weighted.isChecked()
+        )
+        settings_manager.set_value(
+            Settings.HIGHEST_POSITION, self.highest_position.isChecked()
+        )
+
+    def load_layer_options(self):
+        """
+        Retrieve outputs scenarion layers selection from settings and
+        update the releated ui components
+        """
+
+        self.ncs_with_carbon.setChecked(
+            settings_manager.get_value(
+                Settings.NCS_WITH_CARBON, default=False, setting_type=bool
+            )
+        )
+        self.landuse_project.setChecked(
+            settings_manager.get_value(
+                Settings.LANDUSE_PROJECT, default=False, setting_type=bool
+            )
+        )
+        self.landuse_normalized.setChecked(
+            settings_manager.get_value(
+                Settings.LANDUSE_NORMALIZED, default=False, setting_type=bool
+            )
+        )
+
+        self.landuse_weighted.setChecked(
+            settings_manager.get_value(
+                Settings.LANDUSE_WEIGHTED, default=False, setting_type=bool
+            )
+        )
+
+        self.highest_position.setChecked(
+            settings_manager.get_value(
+                Settings.HIGHEST_POSITION, default=False, setting_type=bool
+            )
+        )
+
     def on_log_message_received(self, message, tag, level):
         """Slot to handle log tab updates and processing logs
 
-        param message: The received message from QGIS message log
+        :param message: The received message from QGIS message log
         :type message: str
 
         :param tag: Message log tag
@@ -1172,7 +1236,9 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
             layer = instance_root.findLayer(layer.id())
             layer_clone = layer.clone()
             parent = layer.parent()
-            group.insertChildNode(0, layer_clone)  # Add to top of group
+            group.insertChildNode(
+                0, layer_clone
+            ) if group is not None else None  # Add to top of group
             parent.removeChildNode(layer)
 
     def post_analysis(self, scenario_result, task, report_manager, progress_dialog):
@@ -1199,6 +1265,25 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
                 os.path.dirname(raster), "weighted_activities"
             )
 
+            # Layer options
+            load_ncs = settings_manager.get_value(
+                Settings.NCS_WITH_CARBON, default=True, setting_type=bool
+            )
+            load_landuse = settings_manager.get_value(
+                Settings.LANDUSE_PROJECT, default=True, setting_type=bool
+            )
+            load_landuse_normalized = settings_manager.get_value(
+                Settings.LANDUSE_NORMALIZED, default=True, setting_type=bool
+            )
+
+            load_landuse_weighted = settings_manager.get_value(
+                Settings.LANDUSE_WEIGHTED, default=False, setting_type=bool
+            )
+
+            load_highest_position = settings_manager.get_value(
+                Settings.HIGHEST_POSITION, default=False, setting_type=bool
+            )
+
             scenario_name = scenario_result.scenario.name
             qgis_instance = QgsProject.instance()
             instance_root = qgis_instance.layerTreeRoot()
@@ -1218,22 +1303,30 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
                 counter += 1
 
             # Groups
+            activity_group = None
+            activity_weighted_group = None
+
             scenario_group = instance_root.insertGroup(0, group_name)
-            activity_group = scenario_group.addGroup(tr(ACTIVITY_GROUP_LAYER_NAME))
-            activity_weighted_group = (
-                scenario_group.addGroup(tr(ACTIVITY_WEIGHTED_GROUP_NAME))
-                if os.path.exists(im_weighted_dir)
-                else None
-            )
-            pathways_group = scenario_group.addGroup(tr(NCS_PATHWAYS_GROUP_LAYER_NAME))
+            if load_landuse:
+                activity_group = scenario_group.addGroup(tr(ACTIVITY_GROUP_LAYER_NAME))
+            if load_landuse_weighted:
+                activity_weighted_group = (
+                    scenario_group.addGroup(tr(ACTIVITY_WEIGHTED_GROUP_NAME))
+                    if os.path.exists(im_weighted_dir)
+                    else None
+                )
+            if load_ncs:
+                pathways_group = scenario_group.addGroup(
+                    tr(NCS_PATHWAYS_GROUP_LAYER_NAME)
+                )
+                pathways_group.setExpanded(False)
+                pathways_group.setItemVisibilityCheckedRecursive(False)
 
             # Group settings
-            activity_group.setExpanded(False)
+            activity_group.setExpanded(False) if activity_group else None
             activity_weighted_group.setExpanded(
                 False
             ) if activity_weighted_group else None
-            pathways_group.setExpanded(False)
-            pathways_group.setItemVisibilityCheckedRecursive(False)
 
             # Add scenario result layer to the canvas with styling
             layer_file = scenario_result.analysis_output.get("OUTPUT")
@@ -1261,98 +1354,110 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
 
             # Add activities and pathways
             activity_index = 0
-            for activity in list_activities:
-                activity_name = activity.name
-                activity_layer = QgsRasterLayer(activity.path, activity.name)
-                activity_layer.setCustomProperty(
-                    ACTIVITY_IDENTIFIER_PROPERTY, str(activity.uuid)
-                )
-                list_pathways = activity.pathways
-
-                # Add activity layer with styling, if available
-                if activity_layer:
-                    renderer = self.style_activity_layer(activity_layer, activity)
-
-                    added_activity_layer = qgis_instance.addMapLayer(activity_layer)
-                    self.move_layer_to_group(added_activity_layer, activity_group)
-
-                    activity_layer.setRenderer(renderer)
-                    activity_layer.triggerRepaint()
-
-                # Add activity pathways
-                if len(list_pathways) > 0:
-                    # im_pathway_group = pathways_group.addGroup(im_name)
-                    activity_pathway_group = pathways_group.insertGroup(
-                        activity_index, activity_name
+            if load_landuse:
+                for activity in list_activities:
+                    activity_name = activity.name
+                    activity_layer = QgsRasterLayer(activity.path, activity.name)
+                    activity_layer.setCustomProperty(
+                        ACTIVITY_IDENTIFIER_PROPERTY, str(activity.uuid)
                     )
-                    activity_pathway_group.setExpanded(False)
+                    list_pathways = activity.pathways
 
-                    pw_index = 0
-                    for pathway in list_pathways:
-                        try:
-                            # pathway_name = pathway.name
-                            pathway_layer = pathway.to_map_layer()
+                    # Add activity layer with styling, if available
+                    if activity_layer:
+                        renderer = self.style_activity_layer(activity_layer, activity)
 
-                            added_pw_layer = qgis_instance.addMapLayer(pathway_layer)
-                            self.move_layer_to_group(
-                                added_pw_layer, activity_pathway_group
+                        added_activity_layer = qgis_instance.addMapLayer(activity_layer)
+                        self.move_layer_to_group(added_activity_layer, activity_group)
+
+                        activity_layer.setRenderer(renderer)
+                        activity_layer.triggerRepaint()
+                    # Add activity pathways
+                    if load_ncs:
+                        if len(list_pathways) > 0:
+                            # im_pathway_group = pathways_group.addGroup(im_name)
+                            activity_pathway_group = pathways_group.insertGroup(
+                                activity_index, activity_name
                             )
+                            activity_pathway_group.setExpanded(False)
 
-                            pathway_layer.triggerRepaint()
+                            pw_index = 0
+                            for pathway in list_pathways:
+                                try:
+                                    # pathway_name = pathway.name
+                                    pathway_layer = pathway.to_map_layer()
 
-                            pw_index = pw_index + 1
-                        except Exception as err:
-                            self.show_message(
-                                tr(
-                                    "An error occurred loading a pathway, "
-                                    "check logs for more information"
-                                ),
-                                level=Qgis.Info,
-                            )
-                            log(
-                                tr(
-                                    "An error occurred loading a pathway, "
-                                    'scenario analysis, error message "{}"'.format(err)
-                                )
-                            )
+                                    added_pw_layer = qgis_instance.addMapLayer(
+                                        pathway_layer
+                                    )
+                                    self.move_layer_to_group(
+                                        added_pw_layer, activity_pathway_group
+                                    )
 
-                activity_index = activity_index + 1
+                                    pathway_layer.triggerRepaint()
+
+                                    pw_index = pw_index + 1
+                                except Exception as err:
+                                    self.show_message(
+                                        tr(
+                                            "An error occurred loading a pathway, "
+                                            "check logs for more information"
+                                        ),
+                                        level=Qgis.Info,
+                                    )
+                                    log(
+                                        tr(
+                                            "An error occurred loading a pathway, "
+                                            'scenario analysis, error message "{}"'.format(
+                                                err
+                                            )
+                                        )
+                                    )
+
+                    activity_index = activity_index + 1
 
             weighted_activities = (
                 task.analysis_weighted_activities if task is not None else []
             )
 
-            for weighted_activity in weighted_activities:
-                weighted_activity_path = weighted_activity.path
-                weighted_activity_name = Path(weighted_activity_path).stem
+            if load_landuse_weighted:
+                for weighted_activity in weighted_activities:
+                    weighted_activity_path = weighted_activity.path
+                    weighted_activity_name = Path(weighted_activity_path).stem
 
-                if not weighted_activity_path.endswith(".tif"):
-                    continue
+                    if not weighted_activity_path.endswith(".tif"):
+                        continue
 
-                activity_weighted_layer = QgsRasterLayer(
-                    weighted_activity_path, weighted_activity_name, QGIS_GDAL_PROVIDER
-                )
+                    activity_weighted_layer = QgsRasterLayer(
+                        weighted_activity_path,
+                        weighted_activity_name,
+                        QGIS_GDAL_PROVIDER,
+                    )
 
-                # Set UUID for easier retrieval
-                activity_weighted_layer.setCustomProperty(
-                    ACTIVITY_IDENTIFIER_PROPERTY, str(weighted_activity.uuid)
-                )
+                    # Set UUID for easier retrieval
+                    activity_weighted_layer.setCustomProperty(
+                        ACTIVITY_IDENTIFIER_PROPERTY, str(weighted_activity.uuid)
+                    )
 
-                renderer = self.style_activity_layer(
-                    activity_weighted_layer, weighted_activity
-                )
-                activity_weighted_layer.setRenderer(renderer)
-                activity_weighted_layer.triggerRepaint()
+                    renderer = self.style_activity_layer(
+                        activity_weighted_layer, weighted_activity
+                    )
+                    activity_weighted_layer.setRenderer(renderer)
+                    activity_weighted_layer.triggerRepaint()
 
-                added_im_weighted_layer = qgis_instance.addMapLayer(
-                    activity_weighted_layer
-                )
-                self.move_layer_to_group(
-                    added_im_weighted_layer, activity_weighted_group
-                )
+                    added_im_weighted_layer = qgis_instance.addMapLayer(
+                        activity_weighted_layer
+                    )
+                    self.move_layer_to_group(
+                        added_im_weighted_layer, activity_weighted_group
+                    )
 
             # Initiate report generation
-            self.run_report(progress_dialog, report_manager)
+            if load_landuse_weighted and load_highest_position:
+                self.run_report(progress_dialog, report_manager)
+            else:
+                progress_dialog.processing_finished()
+
         else:
             # Re-initializes variables if processing were cancelled by the user
             # Not doing this breaks the processing if a user tries to run

--- a/src/cplus_plugin/ui/cplus_settings.ui
+++ b/src/cplus_plugin/ui/cplus_settings.ui
@@ -68,134 +68,6 @@
         </widget>
        </item>
        <item>
-        <widget class="QgsCollapsibleGroupBox" name="mGroupBox">
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="title">
-          <string>Scenario Analysis</string>
-         </property>
-         <property name="collapsed">
-          <bool>false</bool>
-         </property>
-         <layout class="QGridLayout" name="gridLayout">
-          <item row="0" column="0">
-           <widget class="QLabel" name="carbon_coefficien_la">
-            <property name="toolTip">
-             <string>The value that will be used as a coefficient when combining pathways with carbon layers. </string>
-            </property>
-            <property name="text">
-             <string>Coefficient for carbon layers</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QDoubleSpinBox" name="carbon_coefficient_box">
-            <property name="toolTip">
-             <string>The value that will be used as a coefficient when combining pathways with carbon layers. </string>
-            </property>
-            <property name="decimals">
-             <number>1</number>
-            </property>
-            <property name="maximum">
-             <double>5.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>1.000000000000000</double>
-            </property>
-            <property name="value">
-             <double>0.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="lbl_suitability_index">
-            <property name="text">
-             <string>Pathway suitability index</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QDoubleSpinBox" name="suitability_index_box">
-            <property name="decimals">
-             <number>1</number>
-            </property>
-            <property name="maximum">
-             <double>5.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>1.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0" colspan="2">
-           <widget class="QgsCollapsibleGroupBox" name="snapping_group_box">
-            <property name="title">
-             <string>Snapping</string>
-            </property>
-            <property name="checkable">
-             <bool>true</bool>
-            </property>
-            <property name="checked">
-             <bool>false</bool>
-            </property>
-            <layout class="QVBoxLayout" name="verticalLayout">
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_2">
-               <item>
-                <widget class="QLabel" name="resample_method">
-                 <property name="text">
-                  <string>Resample method</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QComboBox" name="resample_method_box"/>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <widget class="QLabel" name="reference_layer_label">
-               <property name="text">
-                <string>Reference layer</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout">
-               <item>
-                <widget class="QgsFileWidget" name="map_layer_file_widget">
-                 <property name="toolTip">
-                  <string>Select the priority layer from the local filesystem.</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QgsMapLayerComboBox" name="map_layer_box">
-                 <property name="toolTip">
-                  <string>Select priority layer from the current QGIS map layers.</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="rescale_values">
-               <property name="text">
-                <string>Rescale values</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
         <widget class="QgsCollapsibleGroupBox" name="sieve_group_box">
          <property name="title">
           <string>Sieve </string>
@@ -209,6 +81,134 @@
          <layout class="QVBoxLayout" name="verticalLayout_2">
           <item>
            <layout class="QHBoxLayout" name="horizontalLayout_3">
+            <item>
+             <widget class="QgsCollapsibleGroupBox" name="mGroupBox">
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="title">
+               <string>Scenario Analysis</string>
+              </property>
+              <property name="collapsed">
+               <bool>false</bool>
+              </property>
+              <layout class="QGridLayout" name="gridLayout">
+               <item row="0" column="0">
+                <widget class="QLabel" name="carbon_coefficien_la">
+                 <property name="toolTip">
+                  <string>The value that will be used as a coefficient when combining pathways with carbon layers. </string>
+                 </property>
+                 <property name="text">
+                  <string>Coefficient for carbon layers</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QDoubleSpinBox" name="carbon_coefficient_box">
+                 <property name="toolTip">
+                  <string>The value that will be used as a coefficient when combining pathways with carbon layers. </string>
+                 </property>
+                 <property name="decimals">
+                  <number>1</number>
+                 </property>
+                 <property name="maximum">
+                  <double>5.000000000000000</double>
+                 </property>
+                 <property name="singleStep">
+                  <double>1.000000000000000</double>
+                 </property>
+                 <property name="value">
+                  <double>0.000000000000000</double>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="lbl_suitability_index">
+                 <property name="text">
+                  <string>Pathway suitability index</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QDoubleSpinBox" name="suitability_index_box">
+                 <property name="decimals">
+                  <number>1</number>
+                 </property>
+                 <property name="maximum">
+                  <double>5.000000000000000</double>
+                 </property>
+                 <property name="singleStep">
+                  <double>1.000000000000000</double>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0" colspan="2">
+                <widget class="QgsCollapsibleGroupBox" name="snapping_group_box">
+                 <property name="title">
+                  <string>Snapping</string>
+                 </property>
+                 <property name="checkable">
+                  <bool>true</bool>
+                 </property>
+                 <property name="checked">
+                  <bool>false</bool>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout">
+                  <item>
+                   <layout class="QHBoxLayout" name="horizontalLayout_2">
+                    <item>
+                     <widget class="QLabel" name="resample_method">
+                      <property name="text">
+                       <string>Resample method</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QComboBox" name="resample_method_box"/>
+                    </item>
+                   </layout>
+                  </item>
+                  <item>
+                   <widget class="QLabel" name="reference_layer_label">
+                    <property name="text">
+                     <string>Reference layer</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <layout class="QHBoxLayout" name="horizontalLayout">
+                    <item>
+                     <widget class="QgsFileWidget" name="map_layer_file_widget">
+                      <property name="toolTip">
+                       <string>Select the priority layer from the local filesystem.</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QgsMapLayerComboBox" name="map_layer_box">
+                      <property name="toolTip">
+                       <string>Select priority layer from the current QGIS map layers.</string>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="rescale_values">
+                    <property name="text">
+                     <string>Rescale values</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
             <item>
              <widget class="QLabel" name="resample_method_2">
               <property name="text">
@@ -277,7 +277,7 @@
           <item row="0" column="1">
            <widget class="QToolButton" name="btn_add_mask">
             <property name="toolTip">
-             <string>Add carbon layer</string>
+             <string>Add mask layer</string>
             </property>
             <property name="text">
              <string>...</string>
@@ -287,7 +287,7 @@
           <item row="0" column="2">
            <widget class="QToolButton" name="btn_edit_mask">
             <property name="toolTip">
-             <string>Edit carbon layer</string>
+             <string>Edit mask layer</string>
             </property>
             <property name="text">
              <string>...</string>
@@ -297,7 +297,7 @@
           <item row="0" column="3">
            <widget class="QToolButton" name="btn_delete_mask">
             <property name="toolTip">
-             <string>Remove carbon layer</string>
+             <string>Remove mask layer</string>
             </property>
             <property name="text">
              <string>...</string>

--- a/src/cplus_plugin/ui/qgis_cplus_main_dockwidget.ui
+++ b/src/cplus_plugin/ui/qgis_cplus_main_dockwidget.ui
@@ -453,6 +453,119 @@
         </item>
        </layout>
       </widget>
+      <widget class="QWidget" name="step_4_tab">
+       <attribute name="title">
+        <string>Step 4</string>
+       </attribute>
+       <widget class="QgsCollapsibleGroupBox" name="options_group">
+        <property name="geometry">
+         <rect>
+          <x>10</x>
+          <y>10</y>
+          <width>761</width>
+          <height>201</height>
+         </rect>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select outputs that will be saved into the file system, unselected options will be stored as memory layers.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="title">
+         <string>Select outputs</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_4">
+         <item row="0" column="0">
+          <widget class="QCheckBox" name="ncs_with_carbon">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Whether to produce the NCS pathways outputs.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>NCS with Carbon</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QCheckBox" name="landuse_project">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Whether to produce the landuse project layers outputs.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Landuse Project</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QCheckBox" name="landuse_normalized">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Whether to produce the landuse project normalized outputs.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Landuse Project Normalized</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QCheckBox" name="landuse_weighted">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Whether to produce landuse weighted outputs, unselecting this option will disable report generation this is because weighted output is a required output for report generation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Landuse Project Weighted with PWL</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QCheckBox" name="highest_position">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Whether to produce the final highest position analysis outputs, unselecting this option will disable report generation this is because the highest position output is a required output for report generation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Scenario Highest Position analysis</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QgsCollapsibleGroupBox" name="processing_options_group">
+        <property name="geometry">
+         <rect>
+          <x>10</x>
+          <y>220</y>
+          <width>761</width>
+          <height>101</height>
+         </rect>
+        </property>
+        <property name="toolTip">
+         <string>Processing options</string>
+        </property>
+        <property name="title">
+         <string>Processing options</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_5">
+         <item row="0" column="0">
+          <widget class="QCheckBox" name="processing_type">
+           <property name="text">
+            <string>Process the scenario online</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </widget>
       <widget class="QWidget" name="log">
        <attribute name="title">
         <string>Log</string>


### PR DESCRIPTION
Fixes https://github.com/ConservationInternational/cplus-plugin/issues/322

Implementation of the scenario outputs layers selection enabling user to opt on which layers they want to be part of the final scenario outputs layers.

All layer options are on default checked, when use deselect a listed layer then it will be temporaty stored and not included in the final outputs layer group.

The user selection are store in the plugin settings and loaded once QGIS is reopened.