### PR TITLE
Fix bug in updating plugin default activities

### DIFF
--- a/config.json
+++ b/config.json
@@ -16,7 +16,7 @@
     "author": "Kartoza",
     "email": "info@kartoza.com",
     "description": "QGIS plugin for the CPLUS framework",
-    "version": "0.0.13dev",
+    "version": "0.0.1",
     "changelog": ""
   }
 }

--- a/src/cplus_plugin/main.py
+++ b/src/cplus_plugin/main.py
@@ -524,8 +524,10 @@ def initialize_model_settings():
             continue
 
     for activity in settings_manager.get_all_activities():
+        if activity.user_defined:
+            continue
         if str(activity.uuid) not in new_activities_uuids:
-            settings_manager.activities(str(activity.uuid))
+            settings_manager.remove_activity(str(activity.uuid))
 
     settings_manager.set_value(activity_ncs_setting, True)
 


### PR DESCRIPTION
The original reported bug
![image](https://github.com/ConservationInternational/cplus-plugin/assets/2663775/a71825b8-ab1b-456f-9389-8d2a91ee82df)
