### PR TITLE
Update logs tracking to only processing logs

### DIFF
--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -241,6 +241,11 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
         :type level: Qgis.MessageLevel
         """
         if tag == PLUGIN_MESSAGE_LOG_TAB:
+            # If there is no current running analysis
+            # task don't save the log message.
+            if not self.current_analysis_task:
+                return
+
             message_time = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
             message = (
                 f"{self.log_text_box.toPlainText()} "


### PR DESCRIPTION
Checks if the log messages are related to the currently running processing tasks

Fixes issue when logging a normal plugin log message

![image](https://github.com/ConservationInternational/cplus-plugin/assets/2663775/e0a44ede-931a-483e-a628-021cd6f85ae6)
