### PR TITLE
Disable user to run analysis until activities are selected

### DIFF
--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -1678,7 +1678,7 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
             self.activity_widget.can_show_error_messages = True
             self.activity_widget.load()
 
-        elif index == 2:
+        elif index == 2 or index == 3:
             tab_valid = True
             msg = ""
 


### PR DESCRIPTION
The "Run Scenario" button is now located in the step 4 tab, this PR adds a check for user to selecte at least one activity before using the step 4 tab.