### PR TITLE
Step Two: Check NCS Pathways

### DIFF
--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -1852,6 +1852,17 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
                 msg = self.tr("Please select at least one activity.")
                 tab_valid = False
 
+            # Verify that the selected activities have at least one NCS pathway
+            zero_pathway_activities = []
+            for activity_item in selected_activities:
+                if len(activity_item.ncs_pathways) == 0:
+                    zero_pathway_activities.append(activity_item.activity.name)
+
+            if len(zero_pathway_activities) > 0:
+                tr_msg = self.tr("activities have no NCS pathways defined.")
+                msg = f"{', '.join(zero_pathway_activities)} {tr_msg}"
+                tab_valid = False
+
             if not tab_valid:
                 self.show_message(msg)
                 self.tab_widget.setCurrentIndex(1)

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -1859,8 +1859,13 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
                     zero_pathway_activities.append(activity_item.activity.name)
 
             if len(zero_pathway_activities) > 0:
-                tr_msg = self.tr("activities have no NCS pathways defined.")
-                msg = f"{', '.join(zero_pathway_activities)} {tr_msg}"
+                activity_tr = (
+                    self.tr("activity has")
+                    if len(zero_pathway_activities) == 1
+                    else self.tr("activities have")
+                )
+                tr_msg = self.tr("no NCS pathways defined.")
+                msg = f"{', '.join(zero_pathway_activities)} {activity_tr} {tr_msg}"
                 tab_valid = False
 
             if not tab_valid:


### PR DESCRIPTION
In Step Two, checks if NCS pathways have been defined for the selected activities to be used in the scenario analysis. Shows a warning message to the user for those activities without at least one NCS pathway.

![image](https://github.com/ConservationInternational/cplus-plugin/assets/3840267/64cbc8b1-3ae3-49fd-bf88-738246cae214)
