### PR TITLE
Step Two: Fixes check of NCS pathways in activity items

### DIFF
--- a/src/cplus_plugin/gui/component_item_model.py
+++ b/src/cplus_plugin/gui/component_item_model.py
@@ -569,6 +569,7 @@ class ActivityItem(LayerComponentItem):
         activity = clone_activity(
             self.activity,
         )
+
         # Use NCS pathways with original UUIDs
         activity.pathways = self.original_ncs_pathways
 

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -1868,7 +1868,7 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
             # Verify that the selected activities have at least one NCS pathway
             zero_pathway_activities = []
             for activity_item in selected_activities:
-                if len(activity_item.ncs_pathways) == 0:
+                if len(activity_item.activity.pathways) == 0:
                     zero_pathway_activities.append(activity_item.activity.name)
 
             if len(zero_pathway_activities) > 0:


### PR DESCRIPTION
A fix for checking if there are NCS pathways defined for the selected activity items in Step Two.