### PR TITLE
Fix report cannot open in online task

### DIFF
--- a/src/cplus_plugin/api/scenario_task_api_client.py
+++ b/src/cplus_plugin/api/scenario_task_api_client.py
@@ -90,7 +90,7 @@ class ScenarioAnalysisTaskApiClient(ScenarioAnalysisTask):
                 settings_manager.remove_layer_mapping(identifier)
             except Exception as ex:
                 self.log_message(f"Problem aborting upload layer: {ex}")
-        self.log_message(f"Cancel scenario {self.scenario.uuid}")
+        self.log_message(f"Cancel scenario {self.scenario_api_uuid}")
         if self.scenario_api_uuid and self.scenario_status not in [
             JOB_COMPLETED_STATUS,
             JOB_STOPPED_STATUS,

--- a/src/cplus_plugin/api/scenario_task_api_client.py
+++ b/src/cplus_plugin/api/scenario_task_api_client.py
@@ -62,7 +62,7 @@ class ScenarioAnalysisTaskApiClient(ScenarioAnalysisTask):
         self.total_file_upload_chunks = 0
         self.uploaded_chunks = 0
         self.path_to_layer_mapping = {}
-        self.scenario.uuid = None
+        self.scenario_api_uuid = None
         self.status_pooling = None
         self.logs = []
         self.total_file_output = 0
@@ -91,11 +91,11 @@ class ScenarioAnalysisTaskApiClient(ScenarioAnalysisTask):
             except Exception as ex:
                 self.log_message(f"Problem aborting upload layer: {ex}")
         self.log_message(f"Cancel scenario {self.scenario.uuid}")
-        if self.scenario.uuid and self.scenario_status not in [
+        if self.scenario_api_uuid and self.scenario_status not in [
             JOB_COMPLETED_STATUS,
             JOB_STOPPED_STATUS,
         ]:
-            self.request.cancel_scenario(self.scenario.uuid)
+            self.request.cancel_scenario(self.scenario_api_uuid)
         super().on_terminated()
 
     def run(self) -> bool:
@@ -549,7 +549,7 @@ class ScenarioAnalysisTaskApiClient(ScenarioAnalysisTask):
             {"progress_text": "Submit and execute Scenario to CPLUS API", "progress": 0}
         )
         scenario_uuid = self.request.submit_scenario_detail(self.scenario_detail)
-        self.scenario.uuid = scenario_uuid
+        self.scenario_api_uuid = scenario_uuid
 
         # execute scenario detail
         self.request.execute_scenario(scenario_uuid)

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -1319,7 +1319,6 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
             self.current_analysis_task = analysis_task
 
             progress_dialog.analysis_task = analysis_task
-            progress_dialog.scenario_id = str(scenario.uuid)
 
             report_running = partial(self.on_report_running, progress_dialog)
             report_error = partial(self.on_report_error, progress_dialog)
@@ -1375,6 +1374,7 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
         :type report_manager: ReportManager
         """
 
+        progress_dialog.scenario_id = str(task.scenario.uuid)
         self.scenario_result = task.scenario_result
         self.scenario_results(task, report_manager, progress_dialog)
 

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -1319,6 +1319,7 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
             self.current_analysis_task = analysis_task
 
             progress_dialog.analysis_task = analysis_task
+            progress_dialog.scenario_id = str(scenario.uuid)
 
             report_running = partial(self.on_report_running, progress_dialog)
             report_error = partial(self.on_report_error, progress_dialog)
@@ -1374,7 +1375,6 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
         :type report_manager: ReportManager
         """
 
-        progress_dialog.scenario_id = str(task.scenario.uuid)
         self.scenario_result = task.scenario_result
         self.scenario_results(task, report_manager, progress_dialog)
 


### PR DESCRIPTION
This is PR for https://github.com/ConservationInternational/cplus-plugin/issues/457

When creating `ScenarioAnalysisTask`, `scenario_id` is set to None.
Then, on the nex few lines, the `scenario_id` in `progress_dialog` is set to match the scenario_id.

This causes `progress_dialog`'s `scenario_id` to be None. Causing it not detecting the report result once generated.

What I did in this PR, is using different variable to store Online task UUID, so Scenario ID from local stays intact. 

I've tested for both online and local processing, they both could now show PDF and Layout Manager.

Demo:
https://github.com/ConservationInternational/cplus-plugin/assets/7352963/b88fca0c-9baa-4d6a-b1a0-a50e97c25035