### PR TITLE
Fix saving group UUID at step 3

### DIFF
--- a/src/cplus_plugin/api/scenario_task_api_client.py
+++ b/src/cplus_plugin/api/scenario_task_api_client.py
@@ -202,6 +202,12 @@ class ScenarioAnalysisTaskApiClient(ScenarioAnalysisTask):
         :rtype: List
         """
 
+        self.__update_scenario_status(
+            {
+                "progress_text": f"Uploading layers with concurrent request",
+                "progress": 0,
+            }
+        )
         file_paths = list(upload_dict.keys())
         component_types = list(upload_dict.values())
 

--- a/src/cplus_plugin/conf.py
+++ b/src/cplus_plugin/conf.py
@@ -727,7 +727,7 @@ class SettingsManager(QtCore.QObject):
             for group in groups:
                 group_key = f"{groups_key}/{group['name']}"
                 with qgis_settings(group_key) as group_settings:
-                    group_settings.setValue("uuid", group.get("uuid"))
+                    group_settings.setValue("uuid", str(group.get("uuid")))
                     group_settings.setValue("name", group["name"])
                     group_settings.setValue("value", group["value"])
 

--- a/test/test_priority_layers.py
+++ b/test/test_priority_layers.py
@@ -5,6 +5,7 @@
 """
 
 import unittest
+import uuid
 
 from cplus_plugin.conf import settings_manager
 
@@ -38,6 +39,31 @@ class PriorityLayersTest(unittest.TestCase):
             self.assertEqual(
                 len(settings_manager.get_priority_layers()), len(layers_list)
             )
+
+    def test_priority_layers_groups_with_uuid_obj(self):
+        """Test bug when saving groups in priority layer becomes invalid uuid"""
+        layer = {
+            "uuid": "1f894ea8-32b4-4cac-9b7a-d313db51f816",
+            "name": "Test layer",
+            "description": "Placeholder text for herding for health",
+            "selected": True,
+            "path": [],
+            "groups": [
+                {
+                    "uuid": uuid.UUID("02ce3cf4-7bab-44c2-a607-80c08f747b21"),
+                    "name": "Biodiversity",
+                    "value": "5",
+                }
+            ],
+        }
+        settings_manager.save_priority_layer(layer)
+        layer_settings = settings_manager.get_priority_layer(layer.get("uuid"))
+        self.assertEqual(layer_settings.get("uuid"), layer.get("uuid"))
+        self.assertEqual(layer_settings.get("name"), layer.get("name"))
+        groups = layer_settings.get("groups")
+        self.assertEqual(len(groups), 1)
+        self.assertTrue(isinstance(groups[0].get("uuid"), str))
+        self.assertEqual(groups[0].get("uuid"), str(layer["groups"][0].get("uuid")))
 
     def tearDown(self) -> None:
         settings_manager.delete_priority_layers()


### PR DESCRIPTION
**Issue:**
when uploading scenario detail to the API, the API rejects the payload because the priority group has empty UUID.
![Screenshot_4894](https://github.com/ConservationInternational/cplus-plugin/assets/5819076/90023545-8fa2-4988-b625-82fd875e1328)

**The cause:**
I checked the advanced settings editor for the selected priority layer and found out that the UUID becomes invalid.
![Screenshot_4888](https://github.com/ConservationInternational/cplus-plugin/assets/5819076/cc6bcd4c-36f3-40c5-9e51-12e7056e89f2)

**The fix:**
We need to convert the UUID obj into string before saving into qgis_settings. I also added a unit test to confirm the bug and the fix.
![image](https://github.com/ConservationInternational/cplus-plugin/assets/5819076/1125062a-00bd-490a-b39c-cc4738d47d16)
