### PR TITLE
Fix uploading mask layer

### DIFF
--- a/src/cplus_plugin/api/scenario_task_api_client.py
+++ b/src/cplus_plugin/api/scenario_task_api_client.py
@@ -249,7 +249,6 @@ class ScenarioAnalysisTaskApiClient(ScenarioAnalysisTask):
             {"progress_text": "Checking layers to be uploaded", "progress": 0}
         )
         masking_layers = self.get_masking_layers()
-        masking_layers = [ml.replace(".shp", ".zip") for ml in masking_layers]
 
         # 2 comes from sieve_mask_layer and snap layer
         check_counts = len(self.analysis_activities) + 2 + len(masking_layers)


### PR DESCRIPTION
When we run scenario using API with mask layer shapefile, plugin will first zip it, then upload it. 
The problem arised when when it checks for non existing layer to be uploaded. It should account for the original file (.shp), instead of the zipped file. The zipped file will be accounted when we build Scenario JSON.