### PR TITLE
Add Trends.Earth tooltip

### DIFF
--- a/src/cplus_plugin/gui/settings/cplus_options.py
+++ b/src/cplus_plugin/gui/settings/cplus_options.py
@@ -165,7 +165,7 @@ class DlgSettingsRegister(QtWidgets.QDialog, Ui_DlgSettingsRegister):
                 self.tr(
                     "User registered. Your password "
                     f"has been emailed to {self.email.text()}. "
-                    "Enter that password in Trends.Earth settings "
+                    "Enter that password in CPLUS settings "
                     "to finish setting up the plugin."
                 ),
             )

--- a/src/cplus_plugin/gui/settings/cplus_options.py
+++ b/src/cplus_plugin/gui/settings/cplus_options.py
@@ -223,15 +223,9 @@ class DlgSettingsLogin(QtWidgets.QDialog, Ui_DlgSettingsLogin):
                 None,
                 self.tr("Success"),
                 self.tr(
-                    "Logged in to the Trends.Earth server as "
+                    "Logged in to the CPLUS server as "
                     f"{self.email.text()}.<html><p>Welcome to "
-                    'Trends.Earth!<p/><p><a href= "'
-                    'https://groups.google.com/forum/#!forum/trends_earth_users/join">Join '
-                    "the Trends.Earth Users email group<a/></p><p> Make sure "
-                    "to join the Trends.Earth users email group to keep up "
-                    "with updates and Q&A about the tool, methods, and "
-                    "datasets in support of Sustainable Development Goals "
-                    "monitoring."
+                    "CPLUS!</p><p>You only need to login once.<p></html>"
                 ),
             )
             auth.init_auth_config(

--- a/src/cplus_plugin/ui/cplus_settings.ui
+++ b/src/cplus_plugin/ui/cplus_settings.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>594</width>
-    <height>719</height>
+    <width>609</width>
+    <height>660</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -35,8 +35,8 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-172</y>
-        <width>557</width>
+        <y>-231</y>
+        <width>572</width>
         <height>875</height>
        </rect>
       </property>
@@ -284,6 +284,16 @@
             </property>
            </widget>
           </item>
+          <item row="0" column="1">
+           <widget class="QToolButton" name="btn_add_mask">
+            <property name="toolTip">
+             <string>Add mask layer</string>
+            </property>
+            <property name="text">
+             <string>...</string>
+            </property>
+           </widget>
+          </item>
           <item row="1" column="0" colspan="4">
            <widget class="QListWidget" name="lst_mask_layers"/>
           </item>
@@ -300,26 +310,28 @@
             </property>
            </spacer>
           </item>
-          <item row="0" column="1">
-           <widget class="QToolButton" name="btn_add_mask">
-            <property name="toolTip">
-             <string>Add mask layer</string>
-            </property>
-            <property name="text">
-             <string>...</string>
-            </property>
-           </widget>
-          </item>
          </layout>
         </widget>
        </item>
        <item>
         <widget class="QgsCollapsibleGroupBox" name="groupBox">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>126</height>
+          </size>
+         </property>
          <property name="maximumSize">
           <size>
            <width>16777215</width>
            <height>16777215</height>
           </size>
+         </property>
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Users need to register and login with a trends.earth account to use the online API for processing with CPLUS&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="whatsThis">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Users need to register and login with a trends.earth account to use the online API for processing with CPLUS&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="title">
           <string>Trends.Earth login information</string>

--- a/src/cplus_plugin/ui/cplus_settings.ui
+++ b/src/cplus_plugin/ui/cplus_settings.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>609</width>
-    <height>660</height>
+    <width>594</width>
+    <height>719</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -35,8 +35,8 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-231</y>
-        <width>572</width>
+        <y>-172</y>
+        <width>557</width>
         <height>875</height>
        </rect>
       </property>
@@ -284,16 +284,6 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
-           <widget class="QToolButton" name="btn_add_mask">
-            <property name="toolTip">
-             <string>Add mask layer</string>
-            </property>
-            <property name="text">
-             <string>...</string>
-            </property>
-           </widget>
-          </item>
           <item row="1" column="0" colspan="4">
            <widget class="QListWidget" name="lst_mask_layers"/>
           </item>
@@ -310,17 +300,21 @@
             </property>
            </spacer>
           </item>
+          <item row="0" column="1">
+           <widget class="QToolButton" name="btn_add_mask">
+            <property name="toolTip">
+             <string>Add mask layer</string>
+            </property>
+            <property name="text">
+             <string>...</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>
        <item>
         <widget class="QgsCollapsibleGroupBox" name="groupBox">
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>126</height>
-          </size>
-         </property>
          <property name="maximumSize">
           <size>
            <width>16777215</width>
@@ -328,10 +322,7 @@
           </size>
          </property>
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Users need to register and login with a trends.earth account to use the online API for processing with CPLUS&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="whatsThis">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Users need to register and login with a trends.earth account to use the online API for processing with CPLUS&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Users need to register and login with a Trends.Earth account to use the online API for processing with CPLUS&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="title">
           <string>Trends.Earth login information</string>


### PR DESCRIPTION
This PR adds tooltip on the Trends Earth settings and change registration message.

![image](https://github.com/ConservationInternational/cplus-plugin/assets/7352963/fa4901d3-ea9f-4519-ac9f-30e22e5baea5)
