### PR TITLE
Remove log settings

### DIFF
--- a/src/cplus_plugin/main.py
+++ b/src/cplus_plugin/main.py
@@ -266,7 +266,6 @@ class QgisCplus:
         # Register plugin options factories
         self.iface.registerOptionsWidgetFactory(self.cplus_options_factory)
         self.iface.registerOptionsWidgetFactory(self.reports_options_factory)
-        self.iface.registerOptionsWidgetFactory(self.log_options_factory)
 
         # Register custom layout items
         self.register_layout_items()

--- a/src/cplus_plugin/ui/qgis_cplus_main_dockwidget.ui
+++ b/src/cplus_plugin/ui/qgis_cplus_main_dockwidget.ui
@@ -222,7 +222,7 @@
             </property>
             <property name="icon">
              <iconset>
-              <normaloff>../../../../../../../../../../../resources/cplus_right_arrow.svg</normaloff>../../../../../../../../../../../resources/cplus_right_arrow.svg</iconset>
+              <normaloff>../../../../../../../resources/cplus_right_arrow.svg</normaloff>../../../../../../../resources/cplus_right_arrow.svg</iconset>
             </property>
            </widget>
           </item>
@@ -236,7 +236,7 @@
             </property>
             <property name="icon">
              <iconset>
-              <normaloff>../../../../../../../../../../../resources/cplus_left_arrow.svg</normaloff>../../../../../../../../../../../resources/cplus_left_arrow.svg</iconset>
+              <normaloff>../../../../../../../resources/cplus_left_arrow.svg</normaloff>../../../../../../../resources/cplus_left_arrow.svg</iconset>
             </property>
            </widget>
           </item>
@@ -715,7 +715,7 @@
         <item>
          <widget class="QPushButton" name="options_btn">
           <property name="text">
-           <string>Options</string>
+           <string>Settings</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
This PR removes the `Logs` menu in the CPLUS settings.

Also, the options button has been renamed to `Settings` to be consistent with the text in the plugin menu.
![image](https://github.com/ConservationInternational/cplus-plugin/assets/3840267/c27b66ba-0e70-480e-81a1-1d471f0c1dbe)



