### PR TITLE
Fixed issues in loading saved scenarios

### DIFF
--- a/src/cplus_plugin/gui/priority_layer_dialog.py
+++ b/src/cplus_plugin/gui/priority_layer_dialog.py
@@ -212,9 +212,11 @@ class PriorityLayerDialog(QtWidgets.QDialog, DialogUi):
         layer_id = uuid.uuid4()
         layer_groups = []
         layer = {}
+        layer_type = PriorityLayerType.DEFAULT.value
         if self.layer is not None:
             layer_id = self.layer.get("uuid")
             layer_groups = self.layer.get("groups", [])
+            layer_type = self.layer.get("type", PriorityLayerType.DEFAULT.value)
 
         layer["uuid"] = str(layer_id)
         layer["name"] = self.layer_name.text()
@@ -222,7 +224,7 @@ class PriorityLayerDialog(QtWidgets.QDialog, DialogUi):
         layer["groups"] = layer_groups
 
         layer["path"] = self.map_layer_file_widget.filePath()
-        layer["type"] = self.layer.get("type", PriorityLayerType.DEFAULT.value)
+        layer["type"] = layer_type
         layer[USER_DEFINED_ATTRIBUTE] = self._user_defined
 
         settings_manager.save_priority_layer(layer)

--- a/src/cplus_plugin/trends_earth/api.py
+++ b/src/cplus_plugin/trends_earth/api.py
@@ -15,8 +15,6 @@ import io
 import json
 from urllib.parse import quote_plus
 
-# import backoff
-
 from qgis.core import (
     QgsTask,
     QgsNetworkAccessManager,


### PR DESCRIPTION
When loading the saved scenario with output, the loaded layers had multiple issues including invalid layer paths, wrong crs and empty groups. These changes fix all the issues related to the saved scenario layers.

These changes also include a fix for priority layers editing when editing a PWL with no saved layer.