### PR TITLE
Fix docker compose command usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,9 @@ jobs:
           cat .env
           docker pull "${IMAGE}":${{ matrix.qgis_version_tag }}
           python admin.py build --tests
-          docker-compose up -d
+          docker compose up -d
           sleep 10
 
       - name: Run test suite
         run: |
-          docker-compose exec -T qgis-testing-environment qgis_testrunner.sh test_suite.test_package
+          docker compose exec -T qgis-testing-environment qgis_testrunner.sh test_suite.test_package


### PR DESCRIPTION
Fixed issue with the CI runs now using `docker compose` instead of the `docker-compose` command in running test script.