### PR TITLE
Removed docker config version line.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2.1'
 services:
   qgis-testing-environment:
     image: ${IMAGE}:${QGIS_VERSION_TAG}


### PR DESCRIPTION
Docker compose version property is obsolete, see https://github.com/compose-spec/compose-spec/blob/main/spec.md#version-and-name-top-level-elements.