### PR TITLE
Generate and Validate Activity Gradient Color Ramp

### DIFF
--- a/src/cplus_plugin/gui/activity_editor_dialog.py
+++ b/src/cplus_plugin/gui/activity_editor_dialog.py
@@ -10,8 +10,8 @@ import uuid
 from qgis.core import (
     Qgis,
     QgsColorRamp,
-    QgsFillSymbol,
     QgsFillSymbolLayer,
+    QgsGradientColorRamp,
     QgsMapLayerProxyModel,
     QgsRasterLayer,
 )
@@ -30,7 +30,7 @@ from ..definitions.constants import (
 )
 from ..definitions.defaults import ICON_PATH, USER_DOCUMENTATION_SITE
 from ..models.base import Activity
-from ..utils import FileUtils, open_documentation, tr
+from ..utils import FileUtils, generate_random_color, open_documentation, tr
 
 WidgetUi, _ = loadUiType(
     os.path.join(os.path.dirname(__file__), "../ui/activity_editor_dialog.ui")
@@ -52,10 +52,16 @@ class ActivityEditorDialog(QtWidgets.QDialog, WidgetUi):
         self.style_btn.setSymbolType(Qgis.SymbolType.Fill)
 
         self.btn_color_ramp.setShowNull(False)
-        self.btn_color_ramp.setRandomColorRamp()
+        self.btn_color_ramp.setShowGradientOnly(True)
         self.btn_color_ramp.setColorRampDialogTitle(
             self.tr("Set Color Ramp for Output Activity")
         )
+        # Default gradient colour which closely matches the color
+        # for the activity in the scenario layer
+        start_color = generate_random_color()
+        stop_color = generate_random_color()
+        self.btn_color_ramp.setColorRamp(QgsGradientColorRamp(start_color, stop_color))
+        self.style_btn.setColor(start_color)
 
         self.buttonBox.accepted.connect(self._on_accepted)
         self.btn_select_file.clicked.connect(self._on_select_file)
@@ -218,9 +224,8 @@ class ActivityEditorDialog(QtWidgets.QDialog, WidgetUi):
             self._show_warning_message(msg)
             status = False
 
-        output_model_color_ramp = self.btn_color_ramp.colorRamp()
-        if output_model_color_ramp is None:
-            msg = tr("No color ramp defined for the output model layer.")
+        if self.btn_color_ramp.colorRamp() is None or self.btn_color_ramp.isNull():
+            msg = tr("No color ramp defined for the output activity layer.")
             self._show_warning_message(msg)
             status = False
 

--- a/src/cplus_plugin/utils.py
+++ b/src/cplus_plugin/utils.py
@@ -242,6 +242,16 @@ def calculate_raster_value_area(
     return pixel_areas
 
 
+def generate_random_color() -> QtGui.QColor:
+    """Generate a random color object using a system-seeded
+    deterministic approach.
+
+    :returns: A random generated color.
+    :rtype: QColor
+    """
+    return QtGui.QColor.fromRgb(QtCore.QRandomGenerator.global_().generate())
+
+
 def transform_extent(extent, source_crs, dest_crs):
     """Transforms the passed extent into the destination crs
 


### PR DESCRIPTION
This PR creates a random gradient colour ramp for a new activity and also validates to ensure that a user has selected a non-null colour ramp.

It fixes an issue where the (weighted) activity maps would not display if a user did not specify the style for the output activity layer.