### PR TITLE
Final test feedback

### DIFF
--- a/src/cplus_plugin/api/scenario_history_tasks.py
+++ b/src/cplus_plugin/api/scenario_history_tasks.py
@@ -4,7 +4,6 @@
 
 """
 import datetime
-import json
 import os
 import shutil
 from typing import List
@@ -23,10 +22,11 @@ from ..utils import log
 class FetchScenarioHistoryTask(BaseScenarioTask):
     """Task to fetch scenario history from API."""
 
-    def __init__(self):
+    def __init__(self, main_widget=None):
         """Task initialization."""
         super().__init__()
         self.result = []
+        self.main_widget = main_widget
 
     def run(self):
         """Execute the task logic.
@@ -50,6 +50,8 @@ class FetchScenarioHistoryTask(BaseScenarioTask):
         if is_success:
             self.store_scenario_list(self.result)
         self.task_finished.emit(is_success)
+        if self.main_widget:
+            self.main_widget.update_scenario_list
 
     def store_scenario_list(self, result: List[Scenario]):
         """Store scenario history into settings_manager.

--- a/src/cplus_plugin/api/scenario_task_api_client.py
+++ b/src/cplus_plugin/api/scenario_task_api_client.py
@@ -6,18 +6,18 @@ import typing
 from zipfile import ZipFile
 
 from qgis.core import Qgis
+
 from .request import (
     CplusApiRequest,
     JOB_COMPLETED_STATUS,
     JOB_STOPPED_STATUS,
     CHUNK_SIZE,
 )
-from ..conf import settings_manager, Settings, ScenarioSettings
+from ..api.base import BaseFetchScenarioOutput
+from ..conf import settings_manager, Settings
 from ..models.base import Activity, NcsPathway, Scenario
-from ..models.base import ScenarioResult
 from ..tasks import ScenarioAnalysisTask
 from ..utils import FileUtils, CustomJsonEncoder, todict
-from ..api.base import BaseFetchScenarioOutput
 
 
 def clean_filename(filename):

--- a/src/cplus_plugin/conf.py
+++ b/src/cplus_plugin/conf.py
@@ -518,6 +518,19 @@ class SettingsManager(QtCore.QObject):
                 if str(scenario_identifier) == str(scenario_id):
                     settings.remove(scenario_identifier)
 
+    def delete_online_scenario(self):
+        """Delete online scenario from QGIS settings
+        """
+
+        with qgis_settings(
+            f"{self.BASE_GROUP_NAME}/" f"{self.SCENARIO_GROUP_NAME}"
+        ) as settings:
+            for scenario_identifier in settings.childGroups():
+                scenario = settings_manager.get_scenario(scenario_identifier)
+                if scenario.server_uuid:
+                    settings_manager.delete_scenario_result(scenario_identifier)
+                    settings_manager.delete_scenario(scenario_identifier)
+
     def delete_all_scenarios(self):
         """Deletes all the plugin scenarios settings."""
         with qgis_settings(

--- a/src/cplus_plugin/conf.py
+++ b/src/cplus_plugin/conf.py
@@ -519,8 +519,7 @@ class SettingsManager(QtCore.QObject):
                     settings.remove(scenario_identifier)
 
     def delete_online_scenario(self):
-        """Delete online scenario from QGIS settings
-        """
+        """Delete online scenario from QGIS settings"""
 
         with qgis_settings(
             f"{self.BASE_GROUP_NAME}/" f"{self.SCENARIO_GROUP_NAME}"

--- a/src/cplus_plugin/gui/progress_dialog.py
+++ b/src/cplus_plugin/gui/progress_dialog.py
@@ -155,12 +155,6 @@ class ProgressDialog(QtWidgets.QDialog, Ui_DlgProgress):
         :param message: Message to show on the status bar
         :type message: str
         """
-        if message == "Uploading layers with concurrent request":
-            self.btn_hide.setEnabled(False)
-            self.btn_hide.setToolTip('Cannot minimize task when uploading layers')
-        else:
-            self.btn_hide.setEnabled(True)
-            self.btn_hide.setToolTip('Run online scenario in background')
 
         if message:
             self.lbl_status.setText(message)
@@ -309,6 +303,22 @@ class OnlineProgressDialog(Ui_DlgOnlineProgress, ProgressDialog):
         # Connections
         self.btn_hide.clicked.connect(self.hide_clicked)
 
+    def change_status_message(self, message=None) -> None:
+        """Updates the status message
+
+        :param message: Message to show on the status bar
+        :type message: str
+        """
+        if message == "Uploading layers with concurrent request":
+            self.btn_hide.setEnabled(False)
+            self.btn_hide.setToolTip('Cannot minimize task when uploading layers')
+        else:
+            self.btn_hide.setEnabled(True)
+            self.btn_hide.setToolTip('Run online scenario in background')
+
+        if message:
+            self.lbl_status.setText(message)
+
     def hide_clicked(self) -> None:
         """User clicked hide.
 
@@ -416,6 +426,7 @@ class ReportProgressDialog(ProgressDialog):
         self.btn_view_report.setEnabled(True)
         icon = self.style().standardIcon(QStyle.SP_DialogCloseButton)
         self.btn_cancel.setIcon(icon)
+        self.btn_hide.setEnabled(False)
 
         self.report_running = False
 

--- a/src/cplus_plugin/gui/progress_dialog.py
+++ b/src/cplus_plugin/gui/progress_dialog.py
@@ -155,6 +155,12 @@ class ProgressDialog(QtWidgets.QDialog, Ui_DlgProgress):
         :param message: Message to show on the status bar
         :type message: str
         """
+        if message == "Uploading layers with concurrent request":
+            self.btn_hide.setEnabled(False)
+            self.btn_hide.setToolTip('Cannot minimize task when uploading layers')
+        else:
+            self.btn_hide.setEnabled(True)
+            self.btn_hide.setToolTip('Run online scenario in background')
 
         if message:
             self.lbl_status.setText(message)
@@ -422,6 +428,7 @@ class ReportProgressDialog(ProgressDialog):
         # Change cancel button to the close button status
         self.btn_cancel.setText(tr("Close"))
         self.btn_view_report.setEnabled(False)
+        self.btn_hide.setEnabled(False)
 
         self.report_running = False
 
@@ -436,6 +443,7 @@ class ReportProgressDialog(ProgressDialog):
             # Change cancel button to the close button status
             self.btn_cancel.setText(tr("Close"))
             self.btn_view_report.setEnabled(False)
+            self.btn_hide.setEnabled(False)
 
             self.change_status_message(tr("Report generation canceled."))
         else:

--- a/src/cplus_plugin/gui/progress_dialog.py
+++ b/src/cplus_plugin/gui/progress_dialog.py
@@ -311,10 +311,10 @@ class OnlineProgressDialog(Ui_DlgOnlineProgress, ProgressDialog):
         """
         if message == "Uploading layers with concurrent request":
             self.btn_hide.setEnabled(False)
-            self.btn_hide.setToolTip('Cannot minimize task when uploading layers')
+            self.btn_hide.setToolTip("Cannot minimize task when uploading layers")
         else:
             self.btn_hide.setEnabled(True)
-            self.btn_hide.setToolTip('Run online scenario in background')
+            self.btn_hide.setToolTip("Run online scenario in background")
 
         if message:
             self.lbl_status.setText(message)

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -209,8 +209,8 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
 
         if online_task:
             if status == JOB_COMPLETED_STATUS:
-                message = f"Task {online_task.name} has completed successfully."
-                button_text = "Generate report"
+                message = f"Task {online_task.name} has completed successfully. You can download the result from Log tab."
+                button_text = "OK"
             elif status == JOB_RUNNING_STATUS:
                 message = f"Task {online_task.name} is still running."
                 button_text = "View status"
@@ -218,15 +218,15 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
                 message = f"Task {online_task.name} is {status}."
                 button_text = "OK"
             widget = self.message_bar.createMessage(tr(message))
-            button = QPushButton(widget)
 
-            button.setText(button_text)
-            if status in [JOB_RUNNING_STATUS, JOB_COMPLETED_STATUS]:
+            if status == JOB_RUNNING_STATUS:
+                button = QPushButton(widget)
+                button.setText(button_text)
                 load_scenario = partial(
                     self.load_scenario, running_online_scenario_uuid
                 )
                 button.pressed.connect(load_scenario)
-            widget.layout().addWidget(button)
+                widget.layout().addWidget(button)
             self.update_message_bar(widget)
 
     def fetch_online_task_status(self):

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -1144,6 +1144,7 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
         """Fetches scenarios from plugin settings and updates the
         scenario history list
         """
+        log('update_scenario_list')
         scenarios = settings_manager.get_scenarios()
 
         if len(scenarios) >= 0:
@@ -1151,6 +1152,7 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
 
         for scenario in scenarios:
             scenario_type = "Available offline"
+            log(str(scenario.name))
             if scenario.server_uuid:
                 scenario_result = settings_manager.get_scenario_result(scenario.uuid)
                 if scenario_result is None:
@@ -1454,6 +1456,7 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
         :param success: True if API call is successful
         :type success: bool
         """
+        log(f'on_fetch_scenario_history_list_finished: {success}')
         if not success:
             return
         self.update_scenario_list()

--- a/src/cplus_plugin/gui/settings/cplus_options.py
+++ b/src/cplus_plugin/gui/settings/cplus_options.py
@@ -40,6 +40,7 @@ from ...definitions.defaults import (
 from ...trends_earth.constants import API_URL, TIMEOUT
 from ...utils import FileUtils, log, tr
 from ...trends_earth import auth, api, download
+from ..qgis_cplus_main import QgisCplusMain
 
 Ui_DlgSettings, _ = uic.loadUiType(
     os.path.join(os.path.dirname(__file__), "../../ui/cplus_settings.ui")
@@ -231,6 +232,11 @@ class DlgSettingsLogin(QtWidgets.QDialog, Ui_TrendsEarthDlgSettingsLogin):
             auth.init_auth_config(
                 auth.TE_API_AUTH_SETUP, self.email.text(), self.password.text()
             )
+
+            cplus_main = QgisCplusMain(iface=None)
+            settings_manager.delete_online_scenario()
+            cplus_main.fetch_default_layer_list()
+            cplus_main.fetch_scenario_history_list()
             self.ok = True
             self.close()
 

--- a/src/cplus_plugin/main.py
+++ b/src/cplus_plugin/main.py
@@ -112,11 +112,6 @@ class QgisCplus:
         self.toolBtnAction = self.toolbar.addWidget(self.toolButton)
         self.actions.append(self.toolBtnAction)
 
-        # Create options factories
-        self.cplus_options_factory = CplusOptionsFactory()
-        self.reports_options_factory = ReportOptionsFactory()
-        self.log_options_factory = LogOptionsFactory()
-
         create_priority_layers()
 
         initialize_model_settings()
@@ -132,6 +127,11 @@ class QgisCplus:
         self.main_widget.visibilityChanged.connect(
             self.on_dock_widget_visibility_changed
         )
+
+        # Create options factories
+        self.cplus_options_factory = CplusOptionsFactory(main_widget=self.main_widget)
+        self.reports_options_factory = ReportOptionsFactory()
+        self.log_options_factory = LogOptionsFactory()
 
         self.options_factory = None
 
@@ -333,10 +333,6 @@ class QgisCplus:
             if dock_area == Qt.NoDockWidgetArea and not self.main_widget.isFloating():
                 self.iface.addDockWidget(Qt.RightDockWidgetArea, self.main_widget)
                 self.main_widget.show()
-                # Check online task
-                self.main_widget.fetch_online_task_status()
-                # Scenario list
-                self.main_widget.fetch_scenario_history_list()
 
     def run_settings(self):
         """Options the CPLUS settings in the QGIS options dialog."""


### PR DESCRIPTION
This PR adds:
- Disable `hide` button when uploading layers.
- Auto populate default layers and logs tab when logging into Trends.Earth.
- Update wording when running background scenario task and it's finished.

 ![Screenshot_20240913_213621](https://github.com/user-attachments/assets/28b32b9c-296b-4159-8228-f9a9ba3710e6)

Demo: https://youtu.be/2I09yoBXVQk