### PR TITLE
Fix activities selection in the priority layer dialog 

### DIFF
--- a/src/cplus_plugin/gui/items_selection_dialog.py
+++ b/src/cplus_plugin/gui/items_selection_dialog.py
@@ -135,9 +135,16 @@ class ItemsSelectionDialog(QtWidgets.QDialog, DialogUi):
             item = self.list_widget.item(index)
             if item.checkState() == QtCore.Qt.Checked:
                 items_text.append(item.text())
-        item_names = ",".join(items_text)
-        items = [item for item in items if item.name in item_names]
-        return items
+
+        final_items = []
+
+        for item in items:
+            for item_name in items_text:
+                if item.name == item_name:
+                    final_items.append(item)
+                    break
+
+        return final_items
 
     def unselected_items(self):
         """Returns unselected items from the dialog"""

--- a/src/cplus_plugin/gui/priority_layer_dialog.py
+++ b/src/cplus_plugin/gui/priority_layer_dialog.py
@@ -17,7 +17,7 @@ from qgis.PyQt.uic import loadUiType
 from qgis.gui import QgsFileWidget
 
 from ..conf import settings_manager, Settings
-from ..utils import FileUtils, open_documentation
+from ..utils import FileUtils, open_documentation, log
 from ..models.base import PriorityLayerType
 from ..definitions.defaults import ICON_PATH, PRIORITY_LAYERS, USER_DOCUMENTATION_SITE
 from ..definitions.constants import PRIORITY_LAYERS_SEGMENT, USER_DEFINED_ATTRIBUTE

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -1028,6 +1028,16 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
         group = settings_manager.get_priority_group(group_identifier)
         current_text = group.get("name")
 
+        if current_text is None:
+            self.show_message(
+                tr(
+                    "Couldn't find the priority group,"
+                    " make sure you select the priority group root item."
+                ),
+                Qgis.Critical,
+            )
+            return
+
         if group_identifier is None or group_identifier == "":
             self.show_message(
                 tr("Could not fetch the selected priority group for editing."),

--- a/src/cplus_plugin/ui/qgis_cplus_main_dockwidget.ui
+++ b/src/cplus_plugin/ui/qgis_cplus_main_dockwidget.ui
@@ -87,7 +87,7 @@
     <item>
      <widget class="QTabWidget" name="tab_widget">
       <property name="currentIndex">
-       <number>2</number>
+       <number>0</number>
       </property>
       <widget class="QWidget" name="step_3">
        <attribute name="title">


### PR DESCRIPTION
 Fixes a bug that causes the PWL's aut select all activities that matches the selected activities names.