### PR TITLE
Docs update

### DIFF
--- a/docs/developer/api/core/api_pilot_extent.md
+++ b/docs/developer/api/core/api_pilot_extent.md
@@ -1,9 +1,0 @@
-# Pilot Extent Check
-
-::: src.cplus_plugin.lib.extent_check
-    handler: python
-    options:
-        docstring_style: sphinx
-        heading_level: 1
-        show_source: true
-        show_root_heading: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,7 +59,6 @@ nav:
                 - Feedback: developer/api/core/api_validation_feedback.md
                 - Manager: developer/api/core/api_validation_manager.md
                 - Validators: developer/api/core/api_validation_validators.md
-            - Extents: developer/api/core/api_pilot_extent.md
           - Models:
             - Model base: developer/api/models/api_base.md
             - Helpers: developer/api/models/api_helpers.md


### PR DESCRIPTION
Follow up update from https://github.com/ConservationInternational/cplus-plugin/pull/536
Removes the docs for pilot extent now that the plugin doesn't work with pilot area anymore.