### PR TITLE
Irrecoverable Carbon Reference Layer Default Setting

### DIFF
--- a/src/cplus_plugin/gui/settings/cplus_options.py
+++ b/src/cplus_plugin/gui/settings/cplus_options.py
@@ -822,7 +822,7 @@ class CplusSettings(Ui_DlgSettings, QgsOptionsPageWidget):
 
         source_type_int = settings_manager.get_value(
             Settings.IRRECOVERABLE_CARBON_SOURCE_TYPE,
-            default=DataSourceType.UNDEFINED.value,
+            default=DataSourceType.ONLINE.value,
             setting_type=int,
         )
         if source_type_int == DataSourceType.LOCAL.value:


### PR DESCRIPTION
Set the online data source as the default for the irrecoverable carbon reference layer.