### PR TITLE
Swap steps order sequence

### DIFF
--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -156,7 +156,7 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
 
         # Insert widget for step 2
         self.activity_widget = ActivityContainerWidget(self, self.message_bar)
-        self.tab_widget.insertTab(1, self.activity_widget, self.tr("Step 2"))
+        self.tab_widget.insertTab(2, self.activity_widget, self.tr("Step 3"))
         self.tab_widget.currentChanged.connect(self.on_tab_step_changed)
 
         # Step 3, priority weighting layers initialization
@@ -2421,7 +2421,7 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
             self.activity_widget.can_show_error_messages = True
             self.activity_widget.load()
 
-        elif index == 2 or index == 3:
+        elif index == 3:
             tab_valid = True
             msg = ""
 

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -2417,7 +2417,7 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
         :param index: Zero-based index position of new current tab
         :type index: int
         """
-        if index == 1:
+        if index == 2:
             self.activity_widget.can_show_error_messages = True
             self.activity_widget.load()
 

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -2458,7 +2458,7 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
 
             if not tab_valid:
                 self.show_message(msg)
-                self.tab_widget.setCurrentIndex(1)
+                self.tab_widget.setCurrentIndex(2)
 
             else:
                 self.message_bar.clearWidgets()

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -1931,22 +1931,6 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
             log(f"Problem cancelling task, {e}")
         self.processing_cancelled = True
 
-        # # Analysis processing tasks
-        # try:
-        #     if self.task:
-        #         self.task.cancel()
-        # except Exception as e:
-        #     self.on_progress_dialog_cancelled()
-        #     log(f"Problem cancelling task, {e}")
-        #
-        # # Report generating task
-        # try:
-        #     if self.reporting_feedback:
-        #         self.reporting_feedback.cancel()
-        # except Exception as e:
-        #     self.on_progress_dialog_cancelled()
-        #     log(f"Problem cancelling report generating task, {e}")
-
     def scenario_results(self, task, report_manager, progress_dialog):
         """Called when the task ends. Sets the progress bar to 100 if it finished.
 

--- a/src/cplus_plugin/ui/qgis_cplus_main_dockwidget.ui
+++ b/src/cplus_plugin/ui/qgis_cplus_main_dockwidget.ui
@@ -87,7 +87,7 @@
     <item>
      <widget class="QTabWidget" name="tab_widget">
       <property name="currentIndex">
-       <number>1</number>
+       <number>0</number>
       </property>
       <widget class="QWidget" name="step_1">
        <attribute name="title">

--- a/src/cplus_plugin/ui/qgis_cplus_main_dockwidget.ui
+++ b/src/cplus_plugin/ui/qgis_cplus_main_dockwidget.ui
@@ -87,9 +87,9 @@
     <item>
      <widget class="QTabWidget" name="tab_widget">
       <property name="currentIndex">
-       <number>0</number>
+       <number>1</number>
       </property>
-      <widget class="QWidget" name="step_3">
+      <widget class="QWidget" name="step_1">
        <attribute name="title">
         <string>Step 1</string>
        </attribute>
@@ -179,9 +179,9 @@
         </item>
        </layout>
       </widget>
-      <widget class="QWidget" name="tab_6">
+      <widget class="QWidget" name="step_2">
        <attribute name="title">
-        <string>Step 3</string>
+        <string>Step 2</string>
        </attribute>
        <layout class="QGridLayout" name="gridLayout">
         <item row="3" column="2">


### PR DESCRIPTION
Fixes https://github.com/ConservationInternational/cplus-plugin/issues/615

Interchanges the step 2 and 3 positions moving all step 2 feature to step 3 and from step 3 to step 2.

See attached screeshots

| Old sequence | New sequence |
|-----------------|--------------------|
| ![old_tabs](https://github.com/user-attachments/assets/37d29931-2fe0-4881-a915-5332eb1dec71)| ![new_tabs](https://github.com/user-attachments/assets/4586b75d-73ff-46f0-820d-6cec575f20b4)|