### PR TITLE
Fix CRS mismatch in ProjectedCrsValidator

### DIFF
--- a/src/cplus_plugin/api/scenario_task_api_client.py
+++ b/src/cplus_plugin/api/scenario_task_api_client.py
@@ -625,7 +625,7 @@ class ScenarioAnalysisTaskApiClient(ScenarioAnalysisTask, BaseFetchScenarioOutpu
         self.scenario_detail = {
             "scenario_name": old_scenario_dict["name"],
             "scenario_desc": old_scenario_dict["description"],
-            "snapping_enabled": snapping_enabled if sieve_enabled else False,
+            "snapping_enabled": snapping_enabled,
             "snap_layer": snap_layer_path,
             "snap_layer_uuid": snap_layer_uuid,
             "pathway_suitability_index": suitability_index,

--- a/src/cplus_plugin/lib/validation/validators.py
+++ b/src/cplus_plugin/lib/validation/validators.py
@@ -373,11 +373,10 @@ class ProjectedCrsValidator(BaseRuleValidator):
         """
         status = True
 
-        # Dictionary to store CRS definitions: key is CRS ID or 'undefined', value is list of layer names
+        # Dictionary to store CRS definitions: key is CRS ID or 'undefined', value is list of model/layer names
         crs_definitions = {}
         undefined_msg = tr("Undefined")
         invalid_msg = tr("Invalid datasets")
-        geographic_msg = tr("Geographic CRS")
 
         progress = 0.0
         progress_increment = 100.0 / len(self.model_components)
@@ -402,9 +401,7 @@ class ProjectedCrsValidator(BaseRuleValidator):
                     )
                 elif is_geographic:
                     status = False
-                    crs_definitions.setdefault(geographic_msg, []).append(
-                        model_component.name
-                    )
+                    crs_definitions.setdefault(crs, []).append(model_component.name)
 
             progress += progress_increment
             self._set_progress(progress)
@@ -419,7 +416,7 @@ class ProjectedCrsValidator(BaseRuleValidator):
         self._set_progress(100.0)
 
         return status
-    
+
     def _get_crs_and_type(
         self, model_component
     ) -> typing.Tuple[typing.Optional[str], bool]:


### PR DESCRIPTION
Based on #606 

Resolves issue #623 incorrect classification of coordinate systems in the ProjectedCrsValidator.
<table>
<tr>
<td>
<img alt="Before" src="https://github.com/user-attachments/assets/4a110bd5-7ebe-448e-b2eb-9f9d86c912c3"/>
Old View
</td>
<td>
<img alt="After" src="https://github.com/user-attachments/assets/76a69ea1-f27d-4ef0-b57e-f86a304ab9d5" />
New view
</td>
</tr>
</table>

Resolves issue #626: Makes snapping indipendent of sieve in online execution.