### PR TITLE
Downgrade validation category when using reference layer

### DIFF
--- a/src/cplus_plugin/lib/validation/validators.py
+++ b/src/cplus_plugin/lib/validation/validators.py
@@ -28,9 +28,10 @@ from ...models.validation import (
     RuleResult,
     RuleType,
     ValidationResult,
+    ValidationCategory,
 )
 from ...utils import log, tr
-from ...conf import settings_manager
+from ...conf import settings_manager, Settings
 
 
 class BaseRuleValidator:
@@ -273,6 +274,17 @@ class CrsValidator(BaseRuleValidator):
         invalid_msg = tr("Invalid datasets")
         has_undefined = False
 
+        snapping_enabled = settings_manager.get_value(
+            Settings.SNAPPING_ENABLED, default=False, setting_type=bool
+        )
+        snap_layer_path = (
+            settings_manager.get_value(
+                Settings.SNAP_LAYER, default="", setting_type=str
+            )
+            if snapping_enabled
+            else ""
+        )
+
         progress = 0.0
         progress_increment = 100.0 / len(self.model_components)
         self._set_progress(progress)
@@ -333,18 +345,30 @@ class CrsValidator(BaseRuleValidator):
         if len(crs_definitions) > 1 and status:
             status = False
 
+        recommendation_str = self._config.recommendation
         summary = ""
         validate_info = []
         if not status:
             summary = tr("Datasets have different CRS definitions")
             for crs_str, layers in crs_definitions.items():
                 validate_info.append((crs_str, ", ".join(layers)))
+
+            if snapping_enabled and snap_layer_path and Path(snap_layer_path).exists():
+                self._config.category = ValidationCategory.WARNING
+                recommendation_str += tr(
+                    " or the datasets will be reprojected to match the CRS of the reference layer"
+                )
+            else:
+                self._config.category = ValidationCategory.ERROR
+                recommendation_str += tr(
+                    " or specify a reference layer by selecting it through the snapping option in the settings"
+                )
         else:
             summary_tr = tr("All datasets have the same CRS")
             summary = f"{summary_tr} - {list(crs_definitions.keys())[0]}"
 
         self._result = RuleResult(
-            self._config, self._config.recommendation, summary, validate_info
+            self._config, recommendation_str, summary, validate_info
         )
 
         self._set_progress(100.0)


### PR DESCRIPTION
Ressolves issue #625.

When a valid reference layer is specified through the snapping option in the settings, the validation category for CrsValidator, ProjectedCrsValidator and ResolutionValidator is downgraded to a warning and the reference layer is used to reproject the datasets.

<img width="673" alt="image" src="https://github.com/user-attachments/assets/5159ad55-4b50-46ab-a19c-c1785d59964b" />
