### PR TITLE
Use snapping datasets as reference for reprojection

### DIFF
--- a/src/cplus_plugin/gui/settings/cplus_options.py
+++ b/src/cplus_plugin/gui/settings/cplus_options.py
@@ -459,6 +459,7 @@ class CplusSettings(Ui_DlgSettings, QgsOptionsPageWidget):
         self.folder_data.fileChanged.connect(self.base_dir_exists)
 
         self.map_layer_file_widget.setStorageMode(QgsFileWidget.StorageMode.GetFile)
+        self.map_layer_file_widget.fileChanged.connect(self.on_snapping_layer_changed)
         self.map_layer_box.layerChanged.connect(self.map_layer_changed)
 
         self.mask_layer_widget.setStorageMode(QgsFileWidget.StorageMode.GetFile)
@@ -587,6 +588,16 @@ class CplusSettings(Ui_DlgSettings, QgsOptionsPageWidget):
 
         self.save_settings()
 
+    def on_snapping_layer_changed(self, layer):
+        if layer is not None:
+            valid, validation_info = self.validate_snapping_layer(layer)
+            if not valid:
+                iface.messageBar().pushMessage(
+                    "CPLUS - Warning",
+                    f"{tr(validation_info)}: {layer}",
+                    level=qgis.core.Qgis.MessageLevel.Warning,
+                )
+
     def map_layer_changed(self, layer):
         """Sets the file path of the selected layer in file path input
 
@@ -594,6 +605,13 @@ class CplusSettings(Ui_DlgSettings, QgsOptionsPageWidget):
         :type layer: QgsMapLayer
         """
         if layer is not None:
+            valid, validation_info = self.validate_snapping_layer(layer.source())
+            if not valid:
+                iface.messageBar().pushMessage(
+                    "CPLUS - Warning",
+                    f"{tr(validation_info)}: {layer.source()}",
+                    level=qgis.core.Qgis.MessageLevel.Warning,
+                )
             self.map_layer_file_widget.setFilePath(layer.source())
 
     def mask_layer_changed(self, layer):

--- a/src/cplus_plugin/gui/settings/cplus_options.py
+++ b/src/cplus_plugin/gui/settings/cplus_options.py
@@ -461,6 +461,7 @@ class CplusSettings(Ui_DlgSettings, QgsOptionsPageWidget):
         self.map_layer_file_widget.setStorageMode(QgsFileWidget.StorageMode.GetFile)
         self.map_layer_file_widget.fileChanged.connect(self.on_snapping_layer_changed)
         self.map_layer_box.layerChanged.connect(self.map_layer_changed)
+        self.map_layer_box.setFilters(qgis.core.QgsMapLayerProxyModel.RasterLayer)
 
         self.mask_layer_widget.setStorageMode(QgsFileWidget.StorageMode.GetFile)
         self.mask_layer_box.layerChanged.connect(self.mask_layer_changed)

--- a/src/cplus_plugin/ui/cplus_settings.ui
+++ b/src/cplus_plugin/ui/cplus_settings.ui
@@ -158,18 +158,25 @@
               </layout>
              </item>
              <item>
+              <widget class="QLabel" name="reference_layer_label_3">
+                <property name="text">
+                 <string>Reference layer</string>
+                </property>
+              </widget>
+             </item>
+             <item>
               <layout class="QHBoxLayout" name="horizontalLayout">
                <item>
                 <widget class="QgsFileWidget" name="map_layer_file_widget">
                  <property name="toolTip">
-                  <string>Select the priority layer from the local filesystem.</string>
+                  <string>Select the reference layer from the local filesystem.</string>
                  </property>
                 </widget>
                </item>
                <item>
                 <widget class="QgsMapLayerComboBox" name="map_layer_box">
                  <property name="toolTip">
-                  <string>Select priority layer from the current QGIS map layers.</string>
+                  <string>Select reference layer from the current QGIS map layers.</string>
                  </property>
                 </widget>
                </item>


### PR DESCRIPTION
Based on #624 

This PR validates the snapping reference layer by checking the constraints
- Snapping option is enabled.
- A snapping dataset is provided and the path is valid.
- The snapping dataset is of raster type.
- The snapping dataset uses a projected CRS.

See below:

![snapping](https://github.com/user-attachments/assets/e56ac313-7b80-4290-8a8f-97d9b8130c53)
