### PR TITLE
Display data catalogue for default datasets

### DIFF
--- a/src/cplus_plugin/api/request.py
+++ b/src/cplus_plugin/api/request.py
@@ -975,6 +975,9 @@ class CplusApiRequest:
                 "size": layer.get("size"),
                 "layer_type": layer.get("layer_type"),
                 "metadata": layer.get("metadata", {}),
+                "filename": layer.get("filename"),
+                "created_on": layer.get("created_on"),
+                "url": layer.get("url"),
             }
             if component_type in data:
                 data[component_type].append(out_layer)

--- a/src/cplus_plugin/gui/settings/cplus_options.py
+++ b/src/cplus_plugin/gui/settings/cplus_options.py
@@ -613,7 +613,7 @@ class CplusSettings(Ui_DlgSettings, QgsOptionsPageWidget):
         if layer is not None:
             valid, validation_info = self.validate_snapping_layer(layer)
             if not valid:
-                iface.messageBar().pushMessage(
+                self.message_bar.pushMessage(
                     "CPLUS - Warning",
                     f"{tr(validation_info)}: {layer}",
                     level=qgis.core.Qgis.MessageLevel.Warning,
@@ -628,7 +628,7 @@ class CplusSettings(Ui_DlgSettings, QgsOptionsPageWidget):
         if layer is not None:
             valid, validation_info = self.validate_snapping_layer(layer.source())
             if not valid:
-                iface.messageBar().pushMessage(
+                self.message_bar.pushMessage(
                     "CPLUS - Warning",
                     f"{tr(validation_info)}: {layer.source()}",
                     level=qgis.core.Qgis.MessageLevel.Warning,
@@ -734,6 +734,11 @@ class CplusSettings(Ui_DlgSettings, QgsOptionsPageWidget):
                     )
                     settings_manager.set_value(Settings.SNAP_LAYER, snap_layer_path)
                 else:
+                    self.message_bar.pushMessage(
+                        "CPLUS - Warning",
+                        f"{tr(validation_info)}: {snap_layer_path}",
+                        level=qgis.core.Qgis.MessageLevel.Warning,
+                    )
                     iface.messageBar().pushMessage(
                         "CPLUS - Warning",
                         f"{tr(validation_info)}: {snap_layer_path}",

--- a/src/cplus_plugin/gui/settings/cplus_options.py
+++ b/src/cplus_plugin/gui/settings/cplus_options.py
@@ -468,7 +468,6 @@ class CplusSettings(Ui_DlgSettings, QgsOptionsPageWidget):
 
         self.map_layer_file_widget.setStorageMode(QgsFileWidget.StorageMode.GetFile)
         self.map_layer_file_widget.fileChanged.connect(self.on_snapping_layer_changed)
-        self.map_layer_box.layerChanged.connect(self.map_layer_changed)
         self.map_layer_box.setFilters(qgis.core.QgsMapLayerProxyModel.RasterLayer)
 
         self.mask_layer_widget.setStorageMode(QgsFileWidget.StorageMode.GetFile)
@@ -618,22 +617,6 @@ class CplusSettings(Ui_DlgSettings, QgsOptionsPageWidget):
                     f"{tr(validation_info)}: {layer}",
                     level=qgis.core.Qgis.MessageLevel.Warning,
                 )
-
-    def map_layer_changed(self, layer):
-        """Sets the file path of the selected layer in file path input
-
-        :param layer: Qgis map layer
-        :type layer: QgsMapLayer
-        """
-        if layer is not None:
-            valid, validation_info = self.validate_snapping_layer(layer.source())
-            if not valid:
-                self.message_bar.pushMessage(
-                    "CPLUS - Warning",
-                    f"{tr(validation_info)}: {layer.source()}",
-                    level=qgis.core.Qgis.MessageLevel.Warning,
-                )
-            self.map_layer_file_widget.setFilePath(layer.source())
 
     def mask_layer_changed(self, layer):
         """Sets the file path of the selected mask layer in file path input

--- a/src/cplus_plugin/gui/settings/cplus_options.py
+++ b/src/cplus_plugin/gui/settings/cplus_options.py
@@ -1259,30 +1259,32 @@ class CplusSettings(Ui_DlgSettings, QgsOptionsPageWidget):
         self.btn_delete_mask.setEnabled(contains_items)
 
     def _on_add_pwl_layer(self, activated: bool):
-        selected_layer = self._get_selected_pwl_layer()
-        if not selected_layer:
-            error_tr = tr("Select a default layer first.")
-            self.message_bar.pushMessage(error_tr, qgis.core.Qgis.MessageLevel.Warning)
-            return
-        layer_uuid = selected_layer[0]
+        """Slot raised to add a new PWL layer."""
+        pass
+        # TODO: Implement add a new layer to the default PWLs
 
     def _on_edit_pwl_layer(self, activated: bool):
+        """Slot raised to edit a selected PWL layer."""
         selected_layer = self._get_selected_pwl_layer()
         if not selected_layer:
             error_tr = tr("Select a default layer first.")
             self.message_bar.pushMessage(error_tr, qgis.core.Qgis.MessageLevel.Warning)
             return
         layer_uuid = selected_layer[0]
+        # TODO: Implement edit the selected layer functionality
 
     def _on_remove_pwl_layer(self, activated: bool):
+        """Slot raised to remove a selected PWL layer."""
         selected_layer = self._get_selected_pwl_layer()
         if not selected_layer:
             error_tr = tr("Select a default layer first.")
             self.message_bar.pushMessage(error_tr, qgis.core.Qgis.MessageLevel.Warning)
             return
         layer_uuid = selected_layer[0]
+        # TODO: Implement delete the selected layer from the list
 
     def _on_download_pwl_layer(self, activated: bool):
+        """Slot raised to download a selected PWL layer."""
         selected_layer = self._get_selected_pwl_layer()
         if not selected_layer:
             error_tr = tr("Select a default layer first.")
@@ -1326,13 +1328,13 @@ class CplusSettings(Ui_DlgSettings, QgsOptionsPageWidget):
         self.btn_delete_pwl.setEnabled(contains_items)
 
     def _get_selected_pwl_layer(self):
-        """Get the currently selected PWL layer from the table."""
-        selected_indexes = self.tbl_pwl_layers.selectedIndexes()
-        if not selected_indexes:
-            return None
+        """Get the currently selected PWL layer from the table.
+        Returns:
+            list: A list containing the selected layer's data in the order of the PWLs table columns.
+            None: If no layer is selected.
+        """
 
         selected_indexes = self.tbl_pwl_layers.selectionModel().selectedIndexes()
-
         if not selected_indexes:
             return None  # No selection
 

--- a/src/cplus_plugin/gui/settings/cplus_options.py
+++ b/src/cplus_plugin/gui/settings/cplus_options.py
@@ -1267,30 +1267,23 @@ class CplusSettings(Ui_DlgSettings, QgsOptionsPageWidget):
         """Slot raised to edit a selected PWL layer."""
         selected_layer = self._get_selected_pwl_layer()
         if not selected_layer:
-            error_tr = tr("Select a default layer first.")
+            error_tr = tr("Select a default layer first to edit.")
             self.message_bar.pushMessage(error_tr, qgis.core.Qgis.MessageLevel.Warning)
             return
-        layer_uuid = selected_layer[0]
         # TODO: Implement edit the selected layer functionality
 
     def _on_remove_pwl_layer(self, activated: bool):
         """Slot raised to remove a selected PWL layer."""
-        selected_layer = self._get_selected_pwl_layer()
-        if not selected_layer:
-            error_tr = tr("Select a default layer first.")
-            self.message_bar.pushMessage(error_tr, qgis.core.Qgis.MessageLevel.Warning)
+        layer_uuid = self._get_valid_selected_pwl_layer_uuid("remove")
+        if not layer_uuid:
             return
-        layer_uuid = selected_layer[0]
         # TODO: Implement delete the selected layer from the list
 
     def _on_download_pwl_layer(self, activated: bool):
         """Slot raised to download a selected PWL layer."""
-        selected_layer = self._get_selected_pwl_layer()
-        if not selected_layer:
-            error_tr = tr("Select a default layer first.")
-            self.message_bar.pushMessage(error_tr, qgis.core.Qgis.MessageLevel.Warning)
+        layer_uuid = self._get_valid_selected_pwl_layer_uuid("download")
+        if not layer_uuid:
             return
-        layer_uuid = selected_layer[0]
 
         default_layer = None
         for layer in self.default_priority_layers:
@@ -1348,6 +1341,20 @@ class CplusSettings(Ui_DlgSettings, QgsOptionsPageWidget):
             index = self.pwl_model.index(row, column)
             data.append(self.pwl_model.data(index))
         return data
+
+    def _get_valid_selected_pwl_layer_uuid(self, action: str):
+        """Get the UUID of the currently selected PWL layer.
+        Args:
+            action (str): The action being performed (e.g., "edit" "remove", "download").
+        Returns:
+            str: The UUID of the selected layer.
+        """
+        selected_layer = self._get_selected_pwl_layer()
+        if not selected_layer:
+            error_tr = tr(f"Select a default layer first to {action}.")
+            self.message_bar.pushMessage(error_tr, qgis.core.Qgis.MessageLevel.Warning)
+            return None
+        return selected_layer[0]
 
     def validate_snapping_layer(self, snap_layer_path: str) -> typing.Tuple[bool, str]:
         """

--- a/src/cplus_plugin/gui/settings/cplus_options.py
+++ b/src/cplus_plugin/gui/settings/cplus_options.py
@@ -874,7 +874,7 @@ class CplusSettings(Ui_DlgSettings, QgsOptionsPageWidget):
         )
         self.pwl_model = QStandardItemModel()
 
-        headers = ["ID", "Name", "Type", "Size", "CRS", "Version"]
+        headers = ["ID", "Name", "Type", "Size", "CRS", "Version", "Created"]
         for col, header in enumerate(headers):
             item = QStandardItem(header)
             item.setTextAlignment(Qt.AlignLeft | Qt.AlignVCenter)
@@ -891,10 +891,10 @@ class CplusSettings(Ui_DlgSettings, QgsOptionsPageWidget):
                 ),
                 QStandardItem(str(convert_size(pwl.get("size")))),
                 QStandardItem(str(pwl.get("metadata", {}).get("crs"))),
-                QStandardItem(str(pwl.get("version", ""))),
+                QStandardItem(str(pwl.get("version", "v0.0.1"))),
+                QStandardItem(str(pwl.get("created_on"))),
             ]
             self.pwl_model.appendRow(items)
-            print(pwl)
 
         if len(self.default_priority_layers) > 0:
             self.priority_layers_changed()

--- a/src/cplus_plugin/trends_earth/download.py
+++ b/src/cplus_plugin/trends_earth/download.py
@@ -270,6 +270,45 @@ def download_files(urls, out_folder):
     return downloads
 
 
+def download_file(url, out_path):
+    """Download a file from the given URL to the specified output path."""
+
+    if not os.access(os.path.abspath(os.path.join(out_path, os.pardir)), os.W_OK):
+        QtWidgets.QMessageBox.critical(
+            None,
+            tr_download.tr("Error"),
+            tr_download.tr("Unable to write to {}.".format(out_path)),
+        )
+        return None
+
+    if not os.path.exists(out_path) or not check_hash_against_etag(url, out_path):
+        log("Downloading {} to {}".format(url, out_path))
+
+        worker = Download(url, out_path)
+        try:
+            worker.start()
+        except PermissionError:
+            log("Unable to write to {}.".format(out_path))
+            QtWidgets.QMessageBox.critical(
+                None,
+                tr_download.tr("Error"),
+                tr_download.tr("Unable to write to {}.".format(out_path)),
+            )
+            return None
+
+        resp = worker.get_resp()
+        if not resp:
+            log("Error accessing {}.".format(url))
+            QtWidgets.QMessageBox.critical(
+                None,
+                tr_download.tr("Error"),
+                tr_download.tr("Error accessing {}.".format(url)),
+            )
+            return None
+    if os.path.exists(out_path):
+        return out_path
+
+
 def get_admin_bounds() -> typing.Dict[str, Country]:
     raw_admin_bounds = read_json("admin_bounds_key.json.gz", verify=False)
     countries_regions = {}

--- a/src/cplus_plugin/ui/cplus_settings.ui
+++ b/src/cplus_plugin/ui/cplus_settings.ui
@@ -328,7 +328,7 @@
           <bool>false</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout_pwls">
-          <item row="0" column="2">
+          <item row="0" column="3">
            <widget class="QToolButton" name="btn_edit_pwl">
             <property name="toolTip">
              <string>Edit layer</string>
@@ -338,7 +338,7 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="3">
+          <item row="0" column="4">
            <widget class="QToolButton" name="btn_delete_pwl">
             <property name="toolTip">
              <string>Delete layer</string>
@@ -348,7 +348,7 @@
             </property>
            </widget>
           </item>         
-          <item row="1" column="0" colspan="4">
+          <item row="1" column="0" colspan="5">
            <widget class="QTableView" name="tbl_pwl_layers">
             <property name="toolTip">
               <string>Global priority weighted layers (PWLs)</string>
@@ -380,10 +380,20 @@
             </property>
            </spacer>
           </item>
-          <item row="0" column="1">
+          <item row="0" column="2">
            <widget class="QToolButton" name="btn_add_pwl">
             <property name="toolTip">
              <string>Add layer</string>
+            </property>
+            <property name="text">
+             <string>...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QToolButton" name="btn_download_pwl">
+            <property name="toolTip">
+             <string>Download layer</string>
             </property>
             <property name="text">
              <string>...</string>

--- a/src/cplus_plugin/ui/cplus_settings.ui
+++ b/src/cplus_plugin/ui/cplus_settings.ui
@@ -317,6 +317,83 @@
         </widget>
        </item>
        <item>
+        <widget class="QgsCollapsibleGroupBox" name="pwl_layers_box">
+         <property name="title">
+          <string>Global priority weighted layers (PWLs)</string>
+         </property>
+         <property name="collapsed">
+          <bool>false</bool>
+         </property>
+         <property name="saveCheckedState">
+          <bool>false</bool>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_pwls">
+          <item row="0" column="2">
+           <widget class="QToolButton" name="btn_edit_pwl">
+            <property name="toolTip">
+             <string>Edit layer</string>
+            </property>
+            <property name="text">
+             <string>...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="3">
+           <widget class="QToolButton" name="btn_delete_pwl">
+            <property name="toolTip">
+             <string>Delete layer</string>
+            </property>
+            <property name="text">
+             <string>...</string>
+            </property>
+           </widget>
+          </item>         
+          <item row="1" column="0" colspan="4">
+           <widget class="QTableView" name="tbl_pwl_layers">
+            <property name="toolTip">
+              <string>Global priority weighted layers (PWLs)</string>
+            </property>
+            <property name="showGrid">
+              <bool>false</bool>
+            </property>
+            <property name="alternatingRowColors">
+              <bool>true</bool>
+            </property>
+            <property name="selectionBehavior">
+              <enum>QAbstractItemView::SelectRows</enum>
+            </property>
+            <property name="selectionMode">
+              <enum>QAbstractItemView::SingleSelection</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <spacer name="horizontalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>367</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="0" column="1">
+           <widget class="QToolButton" name="btn_add_pwl">
+            <property name="toolTip">
+             <string>Add layer</string>
+            </property>
+            <property name="text">
+             <string>...</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QgsCollapsibleGroupBox" name="gb_ic_reference_layer">
          <property name="minimumSize">
           <size>

--- a/src/cplus_plugin/utils.py
+++ b/src/cplus_plugin/utils.py
@@ -5,6 +5,7 @@
 
 import hashlib
 import json
+import math
 import os
 import typing
 import uuid
@@ -772,3 +773,20 @@ def function_help_to_html(
         html_segments.append("</ul>\n</div>\n")
 
     return "".join(html_segments)
+
+
+def convert_size(size_bytes):
+    """Convert byte size to human readable text.
+
+    :param size_bytes: byte sizse
+    :type size_bytes: int
+    :return: human readable text
+    :rtype: str
+    """
+    if size_bytes == 0:
+        return "0B"
+    size_name = ("B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB")
+    i = int(math.floor(math.log(size_bytes, 1024)))
+    p = math.pow(1024, i)
+    s = round(size_bytes / p, 2)
+    return "%s %s" % (s, size_name[i])


### PR DESCRIPTION
This PR implements the Default Datasets Catalogue interface as outlined in Issue #637, allowing users to explore and manage a full catalogue of available default datasets.

Features Implemented
- UI section under settings listing all default PWL datasets.
- Dataset entries display key metadata, including name, type,size, CRS, version, and date created.

Users can:
- Download and view PWL directly into the map canvas.
- Sort datasets by name, creation date, size, or layer type for easier discovery.

<img alt="image" src="https://github.com/user-attachments/assets/9f8f4340-5906-4938-85e6-be06cfac0995"/>
