### PR TITLE
Manage priority layer

### DIFF
--- a/src/cplus_plugin/api/layer_tasks.py
+++ b/src/cplus_plugin/api/layer_tasks.py
@@ -279,20 +279,28 @@ class CreateUpdateDefaultLayerTask(QgsTask):
             self.handle_upload_cancelled()
             return False
         else:
-            self.request.update_layer_properties(
-                self.layer_uuid,
-                {
-                    "name": self.name,
-                    "description": self.description,
-                    "version": self.version,
-                    "license": self.license,
-                    "component_type": self.component_type,
-                    "privacy_type": self.privacy_type,
-                },
-            )
-            self.progress = 100
-            self.setProgress(self.progress)
-            self.update_progress(100)
+            try:
+                self.request.update_layer_properties(
+                    self.layer_uuid,
+                    {
+                        "name": self.name,
+                        "description": self.description,
+                        "version": self.version,
+                        "license": self.license,
+                        "component_type": self.component_type,
+                        "privacy_type": self.privacy_type,
+                    },
+                )
+                self.progress = 100
+                self.setProgress(self.progress)
+                self.update_progress(100)
+            except Exception as e:
+                self.log_message(traceback.format_exc(), info=False)
+                err = f"Problem updating layer properties in the server: {e}\n"
+                self.log_message(err, info=False)
+                self.set_status_message(err, level=Qgis.Critical)
+                self.cancel_task(e)
+                return False
 
             # Update default layers in the settings
             self.set_status_message("Refreshing layers list")

--- a/src/cplus_plugin/api/layer_tasks.py
+++ b/src/cplus_plugin/api/layer_tasks.py
@@ -3,11 +3,16 @@
  Plugin tasks related to the layer
 """
 
-from qgis.core import QgsTask
+import os
+import json
+import traceback
+import typing
+
+from qgis.core import Qgis, QgsTask, QgsProcessingFeedback, QgsProcessingContext
 from qgis.PyQt import QtCore
 
 from ..conf import settings_manager
-from ..utils import log
+from ..utils import log, tr, CustomJsonEncoder, todict
 from .request import CplusApiRequest
 
 
@@ -90,3 +95,330 @@ class DeleteDefaultLayerTask(QgsTask):
             settings_manager.remove_default_layer(self.layer)
 
         self.task_finished.emit(is_success)
+
+
+class CreateUpdateDefaultLayerTask(QgsTask):
+    """Task for creating or updating default layer in the server"""
+
+    status_message_changed = QtCore.pyqtSignal(str)
+    custom_progress_changed = QtCore.pyqtSignal(float)
+    task_completed = QtCore.pyqtSignal(object)
+
+    def __init__(self, layer: dict, request, chunk_size: int):
+        super().__init__()
+        self.layer = layer
+        self.request = request
+        self.chunk_size = chunk_size
+
+        self.layer_uuid = layer.get("layer_uuid")
+
+        self.is_updated_mode = self.layer_uuid is not None
+
+        self.name = layer.get("name")
+        self.description = layer.get("description")
+        self.version = layer.get("version")
+        self.license = layer.get("license")
+
+        self.component_type = layer.get("component_type", "priority_layer")
+        self.privacy_type = layer.get("privacy_type", "common")
+
+        self.file_path = layer.get("file_path")
+        self.total_size = (
+            os.path.getsize(self.file_path)
+            if os.path.exists(self.file_path) is None
+            else 0
+        )
+        self.progress = 0
+        self.error = None
+        self.upload_id = None
+        self.upload_cancelled = False
+
+    def upload_file(self) -> typing.Dict:
+        """Upload a file as component type to the S3.
+
+        :return: result, containing UUID of the uploaded file, size, and
+            final filename
+        :rtype: typing.Dict
+        """
+
+        self.set_status_message(f"Uploading layer...{self.file_path}")
+        self.uploaded_chunks = 0
+        self.total_file_upload_chunks = 0
+        self.logs = []
+        self.upload_cancelled = False
+
+        self.log_message(f"Uploading {self.file_path}")
+
+        self.total_file_upload_size = os.stat(self.file_path).st_size
+        self.total_file_upload_chunks = self.total_file_upload_size / self.chunk_size
+
+        upload_params = self.request.start_upload_layer(
+            self.file_path,
+            self.component_type,
+            privacy_type=self.privacy_type,
+            uuid=self.layer_uuid,
+            description=self.description,
+            license=self.license,
+            version=self.version,
+        )
+        self.layer_uuid = upload_params["uuid"]
+        self.upload_id = upload_params["multipart_upload_id"]
+        upload_urls = upload_params["upload_urls"]
+        if self.upload_cancelled:
+            return False
+        # store temporary layer
+        temp_layer = {
+            "uuid": self.layer_uuid,
+            "size": os.stat(self.file_path).st_size,
+            "name": os.path.basename(self.file_path),
+            "upload_id": self.upload_id,
+            "path": self.file_path,
+        }
+        settings_manager.save_layer_mapping(temp_layer)
+
+        # do upload by chunks
+        self.upload_items = []
+        with open(self.file_path, "rb") as f:
+            idx = 0
+            while True:
+                if self.upload_cancelled:
+                    break
+                chunk = f.read(self.chunk_size)
+                if not chunk:
+                    break
+                url_item = upload_urls[idx]
+                part_item = self.request.upload_file_part(
+                    url_item["url"], chunk, url_item["part_number"]
+                )
+                if part_item:
+                    self.upload_items.append(part_item)
+                else:
+                    raise Exception(
+                        f"""
+                        Error while uploading {self.file_path}
+                        """
+                    )
+                self.uploaded_chunks += 1
+                self._update_upload_status(
+                    {
+                        "progress_text": "Uploading layers",
+                        "progress": int(
+                            (self.uploaded_chunks / self.total_file_upload_chunks) * 100
+                        ),
+                    }
+                )
+                idx += 1
+                self.progress = int(
+                    (self.uploaded_chunks / self.total_file_upload_chunks) * 100
+                )
+                self.setProgress(self.progress)
+
+        # finish upload
+        result = {"uuid": None}
+        if self.upload_cancelled:
+            return result
+        result = self.request.finish_upload_layer(
+            self.layer_uuid, self.upload_id, self.upload_items
+        )
+
+        self.layer_uuid = result.get("uuid")
+
+        if result:
+            if result.get("status", 200) == 200:
+                self.log_message(
+                    self.tr(
+                        f"""
+                        Layer uploaded successfully.
+                        UUID: {self.layer_uuid}
+                        """
+                    ),
+                )
+                self.set_status_message(
+                    f"Successfully uploaded layer...{self.file_path}"
+                )
+            else:
+                self.log_message(self.tr(result.get("detail", "")))
+
+        return result
+
+    def _update_upload_status(self, response: dict) -> None:
+        """Update upload status in QGIS modal.
+
+        :param response: Response dictionary from Cplus API
+        :type response: dict
+        """
+        self.set_status_message(response.get("progress_text", ""))
+        self.update_progress(response.get("progress", 0))
+
+        if "logs" in response:
+            new_logs = response.get("logs")
+            for log_entry in new_logs:
+                if log_entry not in self.logs:
+                    log_json = json.dumps(log_entry)
+                    self.log_message(log_json)
+            self.logs = new_logs
+
+    def run(self):
+        """Run the task."""
+
+        # upload file if it is provided
+
+        if os.path.exists(self.file_path):
+            try:
+                self.upload_file()
+                self.set_status_message("Layer file uploaded")
+            except Exception as e:
+                self.log_message(traceback.format_exc(), info=False)
+                err = f"Problem uploading layer file to the server: {e}\n"
+                self.log_message(err, info=False)
+                self.set_status_message(err, level=Qgis.Critical)
+                self.cancel_task(e)
+                return False
+        if self.upload_cancelled:
+            self.set_status_message("Cleaning up after cancellation...")
+            self.handle_upload_cancelled()
+            return False
+        else:
+            self.request.update_layer_properties(
+                self.layer_uuid,
+                {
+                    "name": self.name,
+                    "description": self.description,
+                    "version": self.version,
+                    "license": self.license,
+                    "component_type": self.component_type,
+                    "privacy_type": self.privacy_type,
+                },
+            )
+            self.progress = 100
+            self.setProgress(self.progress)
+            self.update_progress(100)
+
+            # Update default layers in the settings
+            self.set_status_message("Refreshing layers list")
+
+        default_layers = self.request.fetch_default_layer_list()
+        settings_manager.save_default_layers(
+            self.component_type, default_layers.get(self.component_type)
+        )
+        settings_manager.priority_layers_changed.emit()
+
+        self.set_status_message("Layer saved")
+
+        return not self.upload_cancelled
+
+    def cancel_task(self, exception=None):
+        """Notifies the task that it should terminate
+
+        :param exception: Exception if stopped with error, defaults to None
+        :type exception: Any, optional
+        """
+        self.error = exception
+        self.cancel()
+
+    def log_message(
+        self,
+        message: str,
+        name: str = "qgis_cplus",
+        info: bool = True,
+        notify: bool = True,
+    ):
+        """Logs the message into QGIS logs using qgis_cplus as the default
+        log instance.
+        If notify_user is True, user will be notified about the log.
+
+        :param message: The log message
+        :type message: str
+
+        :param name: Name of te log instance, qgis_cplus is the default
+        :type message: str
+
+        :param info: Whether the message is about info or a
+            warning
+        :type info: bool
+
+        :param notify: Whether to notify user about the log
+        :type notify: bool
+        """
+        if not isinstance(message, str):
+            if isinstance(message, dict):
+                message = json.dumps(message, cls=CustomJsonEncoder)
+            else:
+                message = json.dumps(todict(message), cls=CustomJsonEncoder)
+        log(message, name=name, info=info, notify=notify)
+
+    def finished(self, is_success: bool):
+        if not self.upload_cancelled:
+            if is_success:
+                self.log_message(tr(f"Finished saving layer {self.name} \n"))
+            else:
+                self.log_message(f"Error while saving the layer: {self.error}")
+        self.task_completed.emit(is_success)
+
+    def set_status_message(self, message: str):
+        """Set status message in progress dialog
+
+        :param message: Message to be displayed
+        :type message: str
+        """
+        self.status_message = message
+        self.status_message_changed.emit(self.status_message)
+
+    def set_custom_progress(self, value: float):
+        """Set task progress value.
+
+        :param value: Value to be set on the progress bar
+        :type value: float
+        """
+        self.custom_progress = min(max(0, float(value)), 100)
+        self.custom_progress_changed.emit(self.custom_progress)
+
+    def update_progress(self, value):
+        """Sets the value of the task progress
+
+        :param value: Value to be set on the progress bar
+        :type value: float
+        """
+        if not self.upload_cancelled:
+            self.set_custom_progress(value)
+        else:
+            self.feedback = QgsProcessingFeedback()
+            self.processing_context = QgsProcessingContext()
+
+    def handle_upload_cancelled(self):
+        """
+        Handles cleanup when an upload is cancelled.
+
+        - If a new layer was being created and upload is cancelled, deletes the layer from the server.
+        - If an upload was in progress (either create or update), aborts the multipart upload on the server.
+
+        This ensures that no incomplete or orphaned layers/files remain on the server after cancellation.
+        """
+        # If creating a new layer and cancelled, delete the incomplete layer
+        if self.layer_uuid is not None and not self.is_updated_mode:
+            try:
+                self.request.delete_layer(self.layer_uuid)
+                self.log_message(f"Deleted incomplete layer {self.layer_uuid}")
+            except Exception as ex:
+                self.log_message(
+                    f"Error deleting incomplete layer {self.layer_uuid}: {ex}",
+                    info=False,
+                )
+            return
+
+        # If an upload was in progress (new or update), abort the multipart upload
+        if self.upload_id and self.layer_uuid and len(self.upload_items) > 0:
+            try:
+                # TODO: Aborting deletes the layer. This is wrong
+                # TODO: Only the MultipartUpload objects for the given upload id should be deleted
+                # TODO: Commented calling the abort until the issue is addressed
+                # self.request.abort_upload_layer(self.layer_uuid, self.upload_id)
+                self.log_message(
+                    f"Aborted upload for layer {self.layer_uuid}, upload_id {self.upload_id}"
+                )
+            except Exception as ex:
+                self.log_message(
+                    f"Error aborting upload for layer {self.layer_uuid}: {ex}",
+                    info=False,
+                )
+            return

--- a/src/cplus_plugin/api/request.py
+++ b/src/cplus_plugin/api/request.py
@@ -978,6 +978,8 @@ class CplusApiRequest:
                 "filename": layer.get("filename"),
                 "created_on": layer.get("created_on"),
                 "url": layer.get("url"),
+                "version": layer.get("version"),
+                "license": layer.get("license"),
             }
             if component_type in data:
                 data[component_type].append(out_layer)

--- a/src/cplus_plugin/api/request.py
+++ b/src/cplus_plugin/api/request.py
@@ -808,7 +808,16 @@ class CplusApiRequest:
         result, _ = self.post(self.urls.layer_check(), payload)
         return result
 
-    def start_upload_layer(self, file_path: str, component_type: str) -> dict:
+    def start_upload_layer(
+        self,
+        file_path: str,
+        component_type: str,
+        privacy_type: str = "private",
+        uuid: str = None,
+        description: str = None,
+        license: str = None,
+        version: str = None,
+    ) -> dict:
         """Request for starting layer upload.
 
         :param file_path: Path of the file to be uploaded
@@ -816,6 +825,22 @@ class CplusApiRequest:
 
         :param component_type: Layer component type, e.g. "ncs_pathway"
         :type component_type: str
+
+        :param privacy_type: Layer privacy type, e.g. "private", "internal",
+            "common", defaults to "private"
+        :type privacy_type: str
+
+        :param uuid: UUID of the layer, optional, defaults to None
+        :type uuid: str
+
+        :param description: Description of the layer, optional, defaults to None
+        :type description: str
+
+        :param version: Version of the layer, optional, defaults to None
+        :type version: str
+
+        :param license: License of the layer, optional, defaults to None
+        :type license: str
 
         :raises CplusApiRequestError: If the request is failing
 
@@ -826,11 +851,23 @@ class CplusApiRequest:
         payload = {
             "layer_type": get_layer_type(file_path),
             "component_type": component_type,
-            "privacy_type": "private",
+            "privacy_type": privacy_type,
             "name": os.path.basename(file_path),
             "size": file_size,
             "number_of_parts": math.ceil(file_size / CHUNK_SIZE),
         }
+
+        # Add optional fields only if they are provided
+        optional_fields = {
+            "uuid": uuid,
+            "description": description,
+            "version": version,
+            "license": license,
+        }
+        for key, value in optional_fields.items():
+            if value:
+                payload[key] = value
+
         result, status_code = self.post(self.urls.layer_upload_start(), payload)
         if status_code != 201:
             raise CplusApiRequestError(result.get("detail", ""))

--- a/src/cplus_plugin/api/request.py
+++ b/src/cplus_plugin/api/request.py
@@ -550,6 +550,31 @@ class CplusApiRequest:
         self._make_request(reply)
         return self._handle_response(url, reply)
 
+    def patch(
+        self, url: str, data: typing.Union[dict, list], headers: dict = {}
+    ) -> typing.Tuple[dict, int]:
+        """Trigger a PATCH request.
+
+        :param url: Cplus API URL
+        :type url: str
+
+        :param data: API payload
+        :type data: typing.Union[dict, list]
+
+        :param headers: header dictionary, defaults to {}
+        :type headers: dict
+
+        :return: tuple of response dictionary and HTTP status code
+        :rtype: typing.Tuple[dict, int]
+        """
+        nam = QgsNetworkAccessManager.instance()
+        headers = headers or self._default_headers()
+        request = self._generate_request(url, headers)
+        json_data = self._get_request_payload(data)
+        reply = nam.sendCustomRequest(request, b"PATCH", json_data)
+        self._make_request(reply)
+        return self._handle_response(url, reply)
+
     def delete(self, url: str, headers: dict = {}) -> typing.Tuple[dict, int]:
         """Trigger a DELETE request.
 
@@ -862,6 +887,25 @@ class CplusApiRequest:
         if status_code != 204:
             raise CplusApiRequestError(result.get("detail", ""))
         return True
+
+    def update_layer_properties(self, layer_uuid: str, properties: dict):
+        """Update layer properties.
+
+        :param layer_uuid: Layer UUID
+        :type layer_uuid: str
+
+        :param properties: properties to be updated
+        :type properties: dict
+
+        :raises CplusApiRequestError: Raises when server return non-204 code
+
+        :return: No content
+        :rtype: dictionary
+        """
+        result, status_code = self.patch(self.urls.layer_detail(layer_uuid), properties)
+        if status_code != 200:
+            raise CplusApiRequestError(result.get("detail", ""))
+        return result
 
     def submit_scenario_detail(self, scenario_detail: dict) -> str:
         """Submitting scenario JSON to Cplus API.

--- a/src/cplus_plugin/gui/settings/cplus_options.py
+++ b/src/cplus_plugin/gui/settings/cplus_options.py
@@ -278,6 +278,7 @@ class DlgSettingsLogin(QtWidgets.QDialog, Ui_TrendsEarthDlgSettingsLogin):
             settings_manager.remove_default_layers()
             self.main_widget.fetch_default_layer_list()
             self.main_widget.fetch_scenario_history_list()
+            self.main_widget.enable_admin_components()
             self.ok = True
             self.close()
 
@@ -535,13 +536,16 @@ class CplusSettings(Ui_DlgSettings, QgsOptionsPageWidget):
 
         self.btn_add_pwl.setIcon(add_icon)
         self.btn_add_pwl.clicked.connect(self._on_add_pwl_layer)
+        self.btn_add_pwl.hide()
 
         self.btn_delete_pwl.setIcon(remove_icon)
         self.btn_delete_pwl.setEnabled(False)
+        self.btn_delete_pwl.hide()
         self.btn_delete_pwl.clicked.connect(self._on_remove_pwl_layer)
 
         self.btn_edit_pwl.setIcon(edit_icon)
         self.btn_edit_pwl.setEnabled(False)
+        self.btn_edit_pwl.hide()
         self.btn_edit_pwl.clicked.connect(self._on_edit_pwl_layer)
 
         # Trends.Earth settings
@@ -611,6 +615,8 @@ class CplusSettings(Ui_DlgSettings, QgsOptionsPageWidget):
         # self.reloadAuthConfigurations()
 
         self.trends_earth_api_client = api.APIClient(API_URL, TIMEOUT)
+
+        self.enable_admin_components()
 
     def apply(self) -> None:
         """This is called on OK click in the QGIS options panel."""
@@ -1551,6 +1557,19 @@ class CplusSettings(Ui_DlgSettings, QgsOptionsPageWidget):
             QtCore.QSettings().setValue(
                 f"{settings_manager.BASE_GROUP_NAME}/{auth.TE_API_AUTH_SETUP.key}", None
             )
+
+    def enable_admin_components(self):
+        user = self.trends_earth_api_client.get_user()
+        if user:
+            self.pwl_layers_box.show()
+        else:
+            self.pwl_layers_box.hide()
+
+        # TODO: Check the role of the user. Show admin components based on roles
+        # if user.get("role") == "USER":
+        self.btn_add_pwl.show()
+        self.btn_edit_pwl.show()
+        self.btn_delete_pwl.show()
 
 
 class CplusOptionsFactory(QgsOptionsWidgetFactory):

--- a/src/cplus_plugin/gui/settings/cplus_options.py
+++ b/src/cplus_plugin/gui/settings/cplus_options.py
@@ -67,6 +67,8 @@ from ...trends_earth.constants import API_URL, TIMEOUT
 from ...utils import FileUtils, log, tr, convert_size
 from ...trends_earth import auth, api, download
 
+from .priority_layer_add import DlgPriorityAddEdit
+
 Ui_DlgSettings, _ = uic.loadUiType(
     os.path.join(os.path.dirname(__file__), "../../ui/cplus_settings.ui")
 )
@@ -1260,8 +1262,8 @@ class CplusSettings(Ui_DlgSettings, QgsOptionsPageWidget):
 
     def _on_add_pwl_layer(self, activated: bool):
         """Slot raised to add a new PWL layer."""
-        pass
-        # TODO: Implement add a new layer to the default PWLs
+        dlg_pwl_add = DlgPriorityAddEdit(parent=self)
+        dlg_pwl_add.exec_()
 
     def _on_edit_pwl_layer(self, activated: bool):
         """Slot raised to edit a selected PWL layer."""
@@ -1270,7 +1272,8 @@ class CplusSettings(Ui_DlgSettings, QgsOptionsPageWidget):
             error_tr = tr("Select a default layer first to edit.")
             self.message_bar.pushMessage(error_tr, qgis.core.Qgis.MessageLevel.Warning)
             return
-        # TODO: Implement edit the selected layer functionality
+        dlg_pwl_add = DlgPriorityAddEdit(parent=self, layer=selected_layer)
+        dlg_pwl_add.exec_()
 
     def _on_remove_pwl_layer(self, activated: bool):
         """Slot raised to remove a selected PWL layer."""

--- a/src/cplus_plugin/gui/settings/priority_layer_add.py
+++ b/src/cplus_plugin/gui/settings/priority_layer_add.py
@@ -299,7 +299,8 @@ class DlgPriorityAddEdit(QtWidgets.QDialog, Ui_PwlDlgAddEdit):
 
         self.upload_running = False
         self.btn_cancel.setText(tr("Close"))
-        self.parent.refresh_default_layers_table()
+        if self.parent:
+            self.parent.refresh_default_layers_table()
 
     def cancel_upload_task(self):
         try:
@@ -315,7 +316,8 @@ class DlgPriorityAddEdit(QtWidgets.QDialog, Ui_PwlDlgAddEdit):
         """Post-steps when uploading is finished."""
 
         self.upload_running = False
-        self.parent.refresh_default_layers_table()
+        if self.parent:
+            self.parent.refresh_default_layers_table()
         self.close()
 
     def status_message_changed(self, message: str) -> None:

--- a/src/cplus_plugin/gui/settings/priority_layer_add.py
+++ b/src/cplus_plugin/gui/settings/priority_layer_add.py
@@ -1,0 +1,335 @@
+import os
+
+import qgis.core
+from qgis.gui import QgsFileWidget, QgsMessageBar
+from qgis.PyQt import uic, QtWidgets, QtCore
+
+from ...api.request import (
+    CplusApiRequest,
+    CHUNK_SIZE,
+)
+from ...api.layer_tasks import CreateUpdateDefaultLayerTask
+from ...models.base import LayerType
+from ...trends_earth import api
+from ...trends_earth.constants import API_URL, TIMEOUT
+from ...utils import log, tr, zip_shapefile, get_layer_type
+
+Ui_PwlDlgAddEdit, _ = uic.loadUiType(
+    os.path.join(os.path.dirname(__file__), "../../ui/priority_layer_add_dialog.ui")
+)
+
+WidgetUi, _ = uic.loadUiType(
+    os.path.join(os.path.dirname(__file__), "../../ui/upload_layer_progress.ui")
+)
+
+
+class UploadProgressDialog(QtWidgets.QDialog, WidgetUi):
+    """Dialog for showing the progress of the uploading priority layer."""
+
+    dialog_closed = QtCore.pyqtSignal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setupUi(self)
+
+        self.btn_cancel = self.buttonBox.button(QtWidgets.QDialogButtonBox.Cancel)
+
+        self.btn_cancel.clicked.connect(self.on_cancel)
+        self.pg_bar.setValue(0)
+
+    def update_status_message(self, message: str = None):
+        """
+        Update the label with the status message.
+
+        param message: The current status message.
+        :type str: message
+        """
+        if message is None:
+            return
+        self.lbl_info.setText(message)
+
+    def update_task_progress(self, progress: float):
+        """Slot raised to update the task progress.
+
+        :param progress: Current progress of the layer upload.
+        :type progress: float
+        """
+        self.pg_bar.setValue(int(progress))
+
+    def on_task_completed(self):
+        """Slot raised when overall layer upload has completed."""
+        self.pg_bar.setValue(100)
+        self.lbl_info.setText(tr("Layer upload completed"))
+        self.close()
+
+    def on_cancel(self):
+        """Slot raised when the Close button has been clicked."""
+        self.dialog_closed.emit()
+
+
+class DlgPriorityAddEdit(QtWidgets.QDialog, Ui_PwlDlgAddEdit):
+    def __init__(
+        self,
+        parent=None,
+        layer: dict = {},
+    ):
+        super().__init__(parent)
+
+        self.setupUi(self)
+        self.layer = layer
+        self.parent = parent
+        self.map_layer_file_widget.setStorageMode(QgsFileWidget.StorageMode.GetFile)
+        self.map_layer_box.layerChanged.connect(self.map_layer_changed)
+        self.rb_common.setChecked(True)
+
+        if self.layer.get("layer_uuid"):
+            self.setWindowTitle(tr("Edit Priority Weighted Layer"))
+            self.txt_name.setText(self.layer.get("name"))
+            self.map_layer_file_widget.setFilePath("")
+            self.txt_description.setPlainText(
+                self.layer.get("metadata", {}).get("description")
+            )
+            self.txt_version.setText(self.layer.get("version", ""))
+            self.txt_license.setPlainText(self.layer.get("license", ""))
+        else:
+            self.setWindowTitle(tr("Add Priority Weighted Layer"))
+
+        self.buttonBox.accepted.connect(self._on_add_edit_pwl)
+        self.buttonBox.rejected.connect(self.cancel_clicked)
+
+        self.btn_cancel = self.buttonBox.button(QtWidgets.QDialogButtonBox.Cancel)
+        self.btn_save = self.buttonBox.button(QtWidgets.QDialogButtonBox.Save)
+
+        self.trends_earth_api_client = api.APIClient(API_URL, TIMEOUT)
+
+        self.upload_running = False
+        self.task = None
+
+        self.grid_layout = QtWidgets.QGridLayout()
+        self.message_bar = QgsMessageBar()
+
+        self.prepare_message_bar()
+
+        self.message_bar.hide()
+
+    @property
+    def privacy_type(self):
+        if self.rb_private.isChecked():
+            return "private"
+        if self.rb_internal.isChecked():
+            return "internal"
+        return "common"
+
+    def prepare_message_bar(self):
+        """Initializes the widget message bar settings"""
+
+        self.message_bar.setSizePolicy(
+            QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Fixed
+        )
+        self.grid_layout.addWidget(
+            self.message_bar, 0, 0, 1, 1, alignment=QtCore.Qt.AlignTop
+        )
+        self.mainLayout.insertLayout(0, self.grid_layout)
+        self.message_bar.clearWidgets()
+
+    def _on_add_edit_pwl(self):
+        if not self.txt_name.text():
+            QtWidgets.QMessageBox.critical(
+                None, self.tr("Error"), self.tr("Enter a name for the layer.")
+            )
+
+            return
+
+        # Only require the file path during the creation of a new layer
+        if (
+            self.layer.get("layer_uuid") is None
+            and not self.map_layer_file_widget.filePath()
+        ):
+            QtWidgets.QMessageBox.critical(
+                None, self.tr("Error"), self.tr("Enter a path to the layer.")
+            )
+
+            return
+
+        if not self.txt_description.toPlainText():
+            QtWidgets.QMessageBox.critical(
+                None, self.tr("Error"), self.tr("Enter a description for the layer.")
+            )
+
+            return
+
+        self.upload_running = True
+
+        self.btn_save.hide()
+        self.message_bar.show()
+
+        request = CplusApiRequest()
+
+        layer_properties = {
+            "name": self.txt_name.text(),
+            "description": self.txt_description.toPlainText(),
+            "file_path": zip_shapefile(self.map_layer_file_widget.filePath()),
+            "version": self.txt_version.text(),
+            "license": self.txt_license.toPlainText(),
+            "component_type": "priority_layer",
+            "privacy_type": self.privacy_type,
+        }
+
+        metadata = self.layer_metadata()
+        if self.map_layer_file_widget.filePath() and os.path.exists(
+            self.map_layer_file_widget.filePath()
+        ):
+            layer_properties["metadata"] = metadata
+
+        self.layer.update(layer_properties)
+
+        self.task = CreateUpdateDefaultLayerTask(
+            layer=self.layer, request=request, chunk_size=CHUNK_SIZE
+        )
+
+        self.task.task_completed.connect(self.uploading_finished)
+        self.task.taskTerminated.connect(self.uploading_cancelled)
+        self.task.status_message_changed.connect(self.status_message_changed)
+        self.task.custom_progress_changed.connect(self.on_progress_changed)
+        qgis.core.QgsApplication.taskManager().addTask(self.task)
+
+        self.progress_dialog = UploadProgressDialog(self)
+        self.progress_dialog.setModal(True)
+        self.progress_dialog.dialog_closed.connect(self.stop_upload)
+        self.progress_dialog.show()
+
+    def layer_metadata(self) -> dict:
+        """
+        Extracts and returns metadata from the selected layer file.
+
+        Returns:
+            dict: A dictionary containing metadata such as layer type, resolution,
+                  nodata value, CRS, unit, and whether the CRS is geographic.
+        """
+        file_path = self.map_layer_file_widget.filePath()
+        layer_type = get_layer_type(file_path)
+        metadata = {
+            "is_raster": layer_type == LayerType.RASTER,
+        }
+
+        layer = None
+
+        if layer_type == LayerType.RASTER:
+            layer = qgis.core.QgsRasterLayer(file_path)
+            if layer.isValid():
+                x_res = layer.rasterUnitsPerPixelX()
+                y_res = layer.rasterUnitsPerPixelY()
+                provider = layer.dataProvider()
+                nodata = (
+                    provider.sourceNoDataValue(1)
+                    if provider and provider.sourceHasNoDataValue(1)
+                    else None
+                )
+                metadata.update(
+                    {
+                        "resolution": [x_res, y_res],
+                        "nodata_value": nodata,
+                    }
+                )
+        elif layer_type == LayerType.VECTOR:
+            layer = qgis.core.QgsVectorLayer(file_path)
+
+        if layer and layer.isValid() and layer.crs() and layer.crs().isValid():
+            crs = layer.crs()
+            metadata.update(
+                {
+                    "crs": crs.authid(),
+                    "unit": crs.mapUnits().name,
+                    "is_geographic": crs.isGeographic(),
+                }
+            )
+
+        return metadata
+
+    def map_layer_changed(self, layer):
+        """Sets the file path of the selected layer in file path input
+
+        :param layer: Qgis map layer
+        :type layer: QgsMapLayer
+        """
+        if layer is not None:
+            self.map_layer_file_widget.setFilePath(layer.source())
+
+    def cancel_clicked(self) -> None:
+        """User clicked cancel.
+        Layer upload will be stopped
+        """
+
+        if self.upload_running:
+            # If cancelled is clicked
+            self.stop_upload()
+            try:
+                if self.task:
+                    self.task.upload_cancelled = True
+                    self.task.cancel()
+            except RuntimeError as e:
+                log("Failed with error :", str(e))
+        super().close()
+
+    def reject(self) -> None:
+        """Called when the dialog is closed"""
+
+        if self.upload_running:
+            self.stop_upload()
+            try:
+                if self.task:
+                    self.task.upload_cancelled = True
+                    self.task.cancel()
+            except RuntimeError as e:
+                log("Failed with error :", str(e))
+
+        super().reject()
+
+    def stop_upload(self, hide=False) -> None:
+        """The user cancelled the layer upload."""
+        # Stops the layer upload task
+        self.cancel_upload_task()
+        self.uploading_cancelled()
+
+    def uploading_cancelled(self) -> None:
+        """Post-steps when layer upload was cancelled."""
+
+        self.upload_running = False
+        self.btn_cancel.setText(tr("Close"))
+        self.parent.refresh_default_layers_table()
+
+    def cancel_upload_task(self):
+        try:
+            if self.task:
+                self.task.upload_cancelled = True
+                self.task.cancel_task()
+        except Exception as e:
+            log(f"Problem cancelling task, {e}")
+
+        self.upload_cancelled = True
+        self.message_bar.hide()
+
+    def uploading_finished(self):
+        """Post-steps when uploading is finished."""
+
+        self.upload_running = False
+        self.parent.refresh_default_layers_table()
+        self.close()
+
+    def status_message_changed(self, message: str) -> None:
+        """Update the status message in the progress dialog.
+
+        :param message: The message to display.
+        :type message: str
+        """
+        self.message_bar.clearWidgets()
+        self.message_bar.pushMessage(message, level=qgis.core.Qgis.Info, duration=5)
+        self.progress_dialog.update_status_message(message)
+
+    def on_progress_changed(self, progress: float) -> None:
+        """Update the progress bar in the progress dialog.
+
+        :param progress: The progress to display.
+        :type progress: float
+        """
+        self.progress_dialog.update_task_progress(progress)

--- a/src/cplus_plugin/gui/settings/priority_layer_add.py
+++ b/src/cplus_plugin/gui/settings/priority_layer_add.py
@@ -110,8 +110,6 @@ class DlgPriorityAddEdit(QtWidgets.QDialog, Ui_PwlDlgAddEdit):
 
         self.prepare_message_bar()
 
-        self.message_bar.hide()
-
     @property
     def privacy_type(self):
         if self.rb_private.isChecked():
@@ -307,7 +305,6 @@ class DlgPriorityAddEdit(QtWidgets.QDialog, Ui_PwlDlgAddEdit):
             log(f"Problem cancelling task, {e}")
 
         self.upload_cancelled = True
-        self.message_bar.hide()
 
     def uploading_finished(self):
         """Post-steps when uploading is finished."""

--- a/src/cplus_plugin/gui/settings/priority_layer_add.py
+++ b/src/cplus_plugin/gui/settings/priority_layer_add.py
@@ -139,8 +139,6 @@ class DlgPriorityAddEdit(QtWidgets.QDialog, Ui_PwlDlgAddEdit):
         self.btn_save.hide()
         self.message_bar.show()
 
-        request = CplusApiRequest()
-
         layer_properties = {
             "name": self.txt_name.text(),
             "description": self.txt_description.toPlainText(),
@@ -151,14 +149,15 @@ class DlgPriorityAddEdit(QtWidgets.QDialog, Ui_PwlDlgAddEdit):
             "privacy_type": self.privacy_type,
         }
 
-        metadata = self.layer_metadata()
         if self.map_layer_file_widget.filePath() and os.path.exists(
             self.map_layer_file_widget.filePath()
         ):
+            metadata = self.layer_metadata()
             layer_properties["metadata"] = metadata
 
         self.layer.update(layer_properties)
 
+        request = CplusApiRequest()
         self.task = CreateUpdateDefaultLayerTask(
             layer=self.layer, request=request, chunk_size=CHUNK_SIZE
         )
@@ -325,8 +324,7 @@ class DlgPriorityAddEdit(QtWidgets.QDialog, Ui_PwlDlgAddEdit):
         :param message: The message to display.
         :type message: str
         """
-        self.message_bar.clearWidgets()
-        self.message_bar.pushMessage(message, level=qgis.core.Qgis.Info, duration=5)
+        self.set_status_message(message)
         self.progress_dialog.update_status_message(message)
 
     def on_progress_changed(self, progress: float) -> None:
@@ -336,3 +334,7 @@ class DlgPriorityAddEdit(QtWidgets.QDialog, Ui_PwlDlgAddEdit):
         :type progress: float
         """
         self.progress_dialog.update_task_progress(progress)
+
+    def set_status_message(self, message, level=0):
+        self.message_bar.clearWidgets()
+        self.message_bar.pushMessage(message, level=level, duration=5)

--- a/src/cplus_plugin/gui/settings/priority_layer_add.py
+++ b/src/cplus_plugin/gui/settings/priority_layer_add.py
@@ -131,29 +131,7 @@ class DlgPriorityAddEdit(QtWidgets.QDialog, Ui_PwlDlgAddEdit):
         self.message_bar.clearWidgets()
 
     def _on_add_edit_pwl(self):
-        if not self.txt_name.text():
-            QtWidgets.QMessageBox.critical(
-                None, self.tr("Error"), self.tr("Enter a name for the layer.")
-            )
-
-            return
-
-        # Only require the file path during the creation of a new layer
-        if (
-            self.layer.get("layer_uuid") is None
-            and not self.map_layer_file_widget.filePath()
-        ):
-            QtWidgets.QMessageBox.critical(
-                None, self.tr("Error"), self.tr("Enter a path to the layer.")
-            )
-
-            return
-
-        if not self.txt_description.toPlainText():
-            QtWidgets.QMessageBox.critical(
-                None, self.tr("Error"), self.tr("Enter a description for the layer.")
-            )
-
+        if not self.is_valid_layer():
             return
 
         self.upload_running = True
@@ -243,6 +221,34 @@ class DlgPriorityAddEdit(QtWidgets.QDialog, Ui_PwlDlgAddEdit):
             )
 
         return metadata
+
+    def is_valid_layer(self) -> bool:
+        """
+        Validates the required fields for adding or editing a priority weighted layer.
+
+        Returns:
+            bool: True if all required fields are valid, False otherwise.
+        """
+        # Check if the layer name is provided
+        if not self.txt_name.text().strip():
+            self.set_status_message(self.tr("Enter a name for the layer."), 1)
+            return False
+
+        # For new layers, ensure a file path is provided
+        if (
+            self.layer.get("layer_uuid") is None
+            and not self.map_layer_file_widget.filePath().strip()
+        ):
+            self.set_status_message(self.tr("Enter a path to the layer."), 1)
+            return False
+
+        # Check if the description is provided
+        if not self.txt_description.toPlainText().strip():
+            self.set_status_message(self.tr("Enter a description for the layer."))
+            return False
+
+        # TODO: Validate the Layer using the validation manager
+        return True
 
     def map_layer_changed(self, layer):
         """Sets the file path of the selected layer in file path input

--- a/src/cplus_plugin/ui/priority_layer_add_dialog.ui
+++ b/src/cplus_plugin/ui/priority_layer_add_dialog.ui
@@ -6,21 +6,85 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>650</width>
+    <width>694</width>
     <height>465</height>
    </rect>
   </property>
-  <property name="sizePolicy">
-   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-    <horstretch>0</horstretch>
-    <verstretch>0</verstretch>
-   </sizepolicy>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
   </property>
   <property name="windowTitle">
    <string>Add global priority weighted layer (PWL)</string>
   </property>
-  <layout class="QVBoxLayout" name="mainLayout">   
-   
+  <layout class="QVBoxLayout" name="mainLayout">
+   <item>
+    <widget class="QFrame" name="frame">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>100</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>100</height>
+      </size>
+     </property>
+     <property name="autoFillBackground">
+      <bool>false</bool>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">background-color: rgb(255, 255, 255);</string>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QLabel" name="icon_la">
+        <property name="maximumSize">
+         <size>
+          <width>91</width>
+          <height>81</height>
+         </size>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="scaledContents">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_123">
+        <property name="text">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add/Edit Default Priority Weighted Layer. Click Help for more information.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="openExternalLinks">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
    <item>
     <widget class="QLabel" name="label_name">
      <property name="sizePolicy">
@@ -98,7 +162,7 @@
       <widget class="QgsFileWidget" name="map_layer_file_widget">
        <property name="toolTip">
         <string>Select the priority layer from the local filesystem.</string>
-       </property>       
+       </property>
       </widget>
      </item>
      <item>
@@ -217,17 +281,28 @@
     </widget>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-        <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-            </sizepolicy>
-        </property>
-        <property name="standardButtons">
-            <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
-        </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item alignment="Qt::AlignLeft">
+      <widget class="QPushButton" name="btn_help">
+       <property name="text">
+        <string>Help</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>
@@ -236,6 +311,17 @@
    <class>QgsFileWidget</class>
    <extends>QWidget</extends>
    <header>qgsfilewidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsSymbolButton</class>
+   <extends>QToolButton</extends>
+   <header>qgssymbolbutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsMapLayerComboBox</class>

--- a/src/cplus_plugin/ui/priority_layer_add_dialog.ui
+++ b/src/cplus_plugin/ui/priority_layer_add_dialog.ui
@@ -1,0 +1,255 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DlgPwlAddEdit</class>
+ <widget class="QDialog" name="DlgPwlAddEdit">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>650</width>
+    <height>465</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Add global priority weighted layer (PWL)</string>
+  </property>
+  <layout class="QVBoxLayout" name="mainLayout">   
+   
+   <item>
+    <widget class="QLabel" name="label_name">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Name</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="txt_name">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>200</width>
+       <height>30</height>
+      </size>
+     </property>
+     <property name="placeholderText">
+      <string>Please enter the name of the layer.</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_description">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Description</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPlainTextEdit" name="txt_description">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>200</width>
+       <height>30</height>
+      </size>
+     </property>
+     <property name="placeholderText">
+      <string>Please enter the layer description.</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Map layer</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QgsFileWidget" name="map_layer_file_widget">
+       <property name="toolTip">
+        <string>Select the priority layer from the local filesystem.</string>
+       </property>       
+      </widget>
+     </item>
+     <item>
+      <widget class="QgsMapLayerComboBox" name="map_layer_box">
+       <property name="toolTip">
+        <string>Select priority layer from the current QGIS map layers.</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="title">
+      <string>Privacy type</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <item>
+       <widget class="QRadioButton" name="rb_private">
+        <property name="text">
+         <string>Private</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="rb_internal">
+        <property name="text">
+         <string>Internal</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="rb_common">
+        <property name="text">
+         <string>Common</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_4">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>License</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPlainTextEdit" name="txt_license">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>200</width>
+       <height>30</height>
+      </size>
+     </property>
+     <property name="placeholderText">
+      <string>Please enter the license information for the layer.</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_3">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Version</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="txt_version">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>200</width>
+       <height>30</height>
+      </size>
+     </property>
+     <property name="inputMethodHints">
+      <set>Qt::ImhNone</set>
+     </property>
+     <property name="echoMode">
+      <enum>QLineEdit::Normal</enum>
+     </property>
+     <property name="placeholderText">
+      <string>Please enter the version the layer.</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+        <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+            </sizepolicy>
+        </property>
+        <property name="standardButtons">
+            <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
+        </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsFileWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfilewidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsMapLayerComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsmaplayercombobox.h</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>txt_name</tabstop>
+  <tabstop>txt_description</tabstop>
+  <tabstop>rb_common</tabstop>
+  <tabstop>txt_license</tabstop>
+  <tabstop>txt_version</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/cplus_plugin/ui/upload_layer_progress.ui
+++ b/src/cplus_plugin/ui/upload_layer_progress.ui
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>LayerUploadProgressDialog</class>
+ <widget class="QDialog" name="LayerUploadProgressDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>353</width>
+    <height>87</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Layer Upload Progress</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="lbl_info">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QProgressBar" name="pg_bar">
+     <property name="value">
+      <number>0</number>
+     </property>
+     <property name="textVisible">
+      <bool>true</bool>
+     </property>
+     <property name="invertedAppearance">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>  
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>LayerUploadProgressDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/cplus_plugin/utils.py
+++ b/src/cplus_plugin/utils.py
@@ -13,6 +13,7 @@ import datetime
 from pathlib import Path
 from uuid import UUID
 from enum import Enum
+from zipfile import ZipFile
 
 from qgis.PyQt import QtCore, QtGui
 from qgis.core import (
@@ -833,3 +834,32 @@ def convert_size(size_bytes):
     p = math.pow(1024, i)
     s = round(size_bytes / p, 2)
     return "%s %s" % (s, size_name[i])
+
+
+def zip_shapefile(shapefile_path: str) -> str:
+    """Zip shapefile to an object with same name.
+    For example, the .shp filename is `test_file.shp`, then the zip file
+    name would be `test_file.zip`
+
+    :param shapefile_path: Path of the shapefile
+    :type shapefile_path: str
+
+    :return: Zip file path if the specified `shapefile_path`
+        ends with .shp, return shapefile_path otherwise
+    :rtype: str
+    """
+
+    if shapefile_path.endswith(".shp"):
+        output_dir = os.path.dirname(shapefile_path)
+        filename_without_ext = os.path.splitext(os.path.basename(shapefile_path))[0]
+        zip_name = shapefile_path.replace(".shp", ".zip")
+        with ZipFile(zip_name, "w") as zip:
+            # writing each file one by one
+            for file in [
+                f
+                for f in os.listdir(output_dir)
+                if filename_without_ext in f and not f.endswith("zip")
+            ]:
+                zip.write(os.path.join(output_dir, file), file)
+        return zip_name
+    return shapefile_path

--- a/src/cplus_plugin/utils.py
+++ b/src/cplus_plugin/utils.py
@@ -15,6 +15,9 @@ from uuid import UUID
 from enum import Enum
 from zipfile import ZipFile
 
+import numpy as np
+from osgeo import gdal
+
 from qgis.PyQt import QtCore, QtGui
 from qgis.core import (
     Qgis,
@@ -27,7 +30,6 @@ from qgis.core import (
     QgsProject,
     QgsProcessing,
     QgsRasterLayer,
-    QgsRectangle,
     QgsUnitTypes,
 )
 
@@ -863,3 +865,125 @@ def zip_shapefile(shapefile_path: str) -> str:
                 zip.write(os.path.join(output_dir, file), file)
         return zip_name
     return shapefile_path
+
+
+def compress_raster(
+    input_path: str,
+    output_path: str = None,
+    compression_type: str = "DEFLATE",
+    compress_level: int = 6,
+    nodata_value: float = None,
+    output_format: str = "GTiff",
+    create_options: list = None,
+    additional_options: list = None,
+):
+    """
+    Compresses a raster file using GDAL and optionally replace old NoData pixel values with a new one.
+
+    :param input_path: Path to the input raster file
+    :type input_path: str
+
+    :param output_path: Path to the input raster file. If none the ouput will saved to a temporary file
+    :type output_path: str
+
+    :param compression_type: Compression algorithm (e.g., 'DEFLATE', 'LZW', 'PACKBITS', 'JPEG', 'NONE')
+    :type compression_type: str
+
+    :param compress_level: Compression level (1-9 for DEFLATE/LZW, 1-100 for JPEG)
+    :type compress_level: int
+
+    :param nodata_value: Value to set as nodata (default: None). If None, retain the input nodatavalue
+    :type nodata_value: float
+
+    :param output_format: Output format (default: 'GTiff' for GeoTIFF)
+    :type output_format: str
+
+    :param create_options: Additional GDAL creation options as a list
+    :type create_options: list
+
+    :param additional_options: dditional GDAL options as a list
+    :type additional_options: list
+
+    :return: Path to the temporary file if successful, None if failed
+    :rtype: str or None
+    """
+    if not os.path.isfile(input_path):
+        raise FileNotFoundError(f"Input raster file not found: {input_path}")
+
+    # Create a temporary file if output_path is None:
+    if not output_path:
+        unique_id = str(uuid.uuid4())[:8]
+        temp_file = QtCore.QTemporaryFile(
+            os.path.join(
+                QgsProject.instance().homePath(), f"temp_compressed_{unique_id}.tif"
+            )
+        )
+        if not temp_file.open():
+            log("Error: Could not create temporary file")
+            return None
+
+        base, ext = os.path.splitext(input_path)
+        output_path = temp_file.fileName() + ext or ".tif"
+        temp_file.close()
+
+    try:
+        # Load the input raster layer using GDAL
+        src_ds = gdal.Open(input_path, gdal.GA_ReadOnly)
+        if src_ds is None:
+            raise ValueError("Unable to open raster with GDAL")
+
+        band_count = src_ds.RasterCount
+        xsize = src_ds.RasterXSize
+        ysize = src_ds.RasterYSize
+        dtype = src_ds.GetRasterBand(1).DataType
+
+        # Add any additional create options
+        if not create_options:
+            create_options = []
+
+        # Ensure standard options are included
+        create_options.extend(
+            [
+                f"COMPRESS={compression_type}",
+                f"ZLEVEL={compress_level}",
+                f"JPEG_QUALITY={compress_level}",
+                f"NUM_THREADS=ALL_CPUS",
+                "BIGTIFF=IF_SAFER",
+                "TILED=YES",
+            ]
+        )
+
+        # Set additional options if provided
+        if additional_options:
+            create_options.extend(additional_options)
+
+        # Create compressed output raster
+        driver = gdal.GetDriverByName(output_format)
+        out_ds = driver.Create(
+            output_path, xsize, ysize, band_count, dtype, create_options
+        )
+        out_ds.SetGeoTransform(src_ds.GetGeoTransform())
+        out_ds.SetProjection(src_ds.GetProjection())
+
+        for i in range(1, band_count + 1):
+            band = src_ds.GetRasterBand(i)
+            data = band.ReadAsArray()
+            old_nodata = band.GetNoDataValue()
+
+            # Replace pixel values if old NoData exists
+            if nodata_value is not None and old_nodata is not None:
+                data = np.where(data == old_nodata, nodata_value, data)
+
+            out_band = out_ds.GetRasterBand(i)
+            out_band.WriteArray(data)
+            out_band.SetNoDataValue(nodata_value)
+            out_band.FlushCache()
+
+        # Close datasets
+        src_ds = None
+        # if os.path.exists(output_path):
+        log(f"Successfully compressed raster saved to temporary file: {output_path}")
+        return output_path
+    except Exception as error:
+        log(f"Error occurred during raster compression. Error code: {error}")
+        return None

--- a/test/data/priority_weighting_layers.py
+++ b/test/data/priority_weighting_layers.py
@@ -1,3 +1,5 @@
+import os
+
 PRIORITY_LAYERS = [
     [
         {
@@ -94,4 +96,36 @@ PRIORITY_GROUPS = [
         "name": "Finance - Carbon",
         "description": "Placeholder text for finance carbon",
     },
+]
+
+PWL_TEST_DATA_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "data",
+    "priority",
+    "layers",
+    "test_priority_1.tif",
+)
+
+DEFAULT_PRIORITY_LAYERS = [
+    {
+        "type": "priority_layer",
+        "layer_uuid": "7a9f87e6-ac58-4156-994d-b808ad0edf2d",
+        "name": "Carbon Sequestration Potential CP norm",
+        "size": 402164317,
+        "layer_type": 0,
+        "metadata": {
+            "crs": "EPSG:4326",
+            "unit": "degree",
+            "is_raster": True,
+            "resolution": [0.00898315284119522, 0.00898315284119522],
+            "nodata_value": -9999.0,
+            "is_geographic": True,
+            "name": "CPLUS: Carbon Sequestration Potential CP norm",
+            "description": "Carbon Sequestration Potential CP norm",
+        },
+        "filename": "Carbon Sequestration Potential CP norm",
+        "path": PWL_TEST_DATA_PATH,
+        "version": "2.0.0",
+        "license": "Apache 2.0",
+    }
 ]

--- a/test/test_default_priority_layer_dialog.py
+++ b/test/test_default_priority_layer_dialog.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for the Default PWL dialog.
+"""
+from unittest import TestCase
+
+from cplus_plugin.conf import settings_manager
+from cplus_plugin.gui.settings.priority_layer_add import DlgPriorityAddEdit
+
+from data.priority_weighting_layers import DEFAULT_PRIORITY_LAYERS, PWL_TEST_DATA_PATH
+
+from utilities_for_testing import get_qgis_app
+
+
+QGIS_APP, CANVAS, IFACE, PARENT = get_qgis_app()
+
+
+class TestDefaultPriorityWeightingLayerDialog(TestCase):
+    """Tests for default PWL dialog."""
+
+    def setUp(self) -> None:
+        self.pwl_path = PWL_TEST_DATA_PATH
+
+    def tearDown(self):
+        """Remove test NCS pathway and PWL in settings."""
+        settings_manager.remove_default_layers()
+
+    def reset_settings(self):
+        """Reset the test NCS pathway amd PWL in settings."""
+        self.tearDown()
+        self.setUp()
+
+    def test_valid_pwl(self):
+        """Assert valid PWL added via the dialog."""
+        self.reset_settings()
+
+        layer_dialog = DlgPriorityAddEdit(parent=PARENT)
+        layer_dialog.txt_name.setText("Test Add Default PWL")
+        layer_dialog.txt_description.setPlainText("Test Default PWL Description")
+        layer_dialog.txt_version.setText("1.0.0")
+        layer_dialog.txt_license.setPlainText("Apache 2.0")
+        layer_dialog.map_layer_file_widget.setFilePath(self.pwl_path)
+        layer_dialog.accept()
+
+        self.assertTrue(layer_dialog.is_valid_layer())
+
+    def test_invalid_pwl(self):
+        """Assert invalid PWL added via the dialog."""
+        self.reset_settings()
+
+        layer_dialog = DlgPriorityAddEdit(parent=PARENT)
+        layer_dialog.txt_name.setText("Test Add Default PWL")
+        layer_dialog.txt_description.setPlainText("Test Default PWL Description")
+        layer_dialog.txt_version.setText("1.0.0")
+        layer_dialog.txt_license.setPlainText("Apache 2.0")
+        # Empty file path
+        layer_dialog.map_layer_file_widget.setFilePath("")
+        layer_dialog.accept()
+
+        self.assertFalse(layer_dialog.is_valid_layer())
+
+    def test_add_pwl(self):
+        """Assert new PWL can be added via the dialog."""
+        self.reset_settings()
+
+        default_layers = settings_manager.get_default_layers("priority_layer")
+        self.assertEqual(len(default_layers), 0)
+
+        layer_dialog = DlgPriorityAddEdit(parent=PARENT)
+        layer_dialog.txt_name.setText("Test Add Default PWL")
+        layer_dialog.txt_description.setPlainText("Test Default PWL Description")
+        layer_dialog.txt_version.setText("1.0.0")
+        layer_dialog.txt_license.setPlainText("Apache 2.0")
+        layer_dialog.map_layer_file_widget.setFilePath(self.pwl_path)
+        layer_dialog.accept()
+
+        saved_pwl = layer_dialog.layer
+        self.assertIsNotNone(saved_pwl)
+
+    def test_edit_pwl(self):
+        """Assert a PWL can be edited via the dialog."""
+        self.reset_settings()
+
+        settings_manager.save_default_layers("priority_layer", DEFAULT_PRIORITY_LAYERS)
+
+        self.assertEqual(len(settings_manager.get_default_layers("priority_layer")), 1)
+
+        pwl = DEFAULT_PRIORITY_LAYERS[0]
+
+        edit_name = "PWL Edited"
+        edit_description = "PWL Edited Description"
+        layer_dialog = DlgPriorityAddEdit(PARENT, pwl)
+        layer_dialog.txt_name.setText(edit_name)
+        layer_dialog.txt_description.setPlainText(edit_description)
+        layer_dialog.map_layer_file_widget.setFilePath(self.pwl_path)
+        layer_dialog._on_add_edit_pwl()
+
+        saved_pwl = layer_dialog.layer
+        self.assertIsNotNone(saved_pwl)
+        self.assertEqual(saved_pwl["name"], edit_name)
+        self.assertEqual(saved_pwl["description"], edit_description)

--- a/test/test_default_priority_layer_dialog.py
+++ b/test/test_default_priority_layer_dialog.py
@@ -93,7 +93,7 @@ class TestDefaultPriorityWeightingLayerDialog(TestCase):
         layer_dialog.txt_name.setText(edit_name)
         layer_dialog.txt_description.setPlainText(edit_description)
         layer_dialog.map_layer_file_widget.setFilePath(self.pwl_path)
-        layer_dialog._on_add_edit_pwl()
+        layer_dialog.accept()
 
         saved_pwl = layer_dialog.layer
         self.assertIsNotNone(saved_pwl)

--- a/test/test_default_priority_layer_dialog.py
+++ b/test/test_default_priority_layer_dialog.py
@@ -93,7 +93,7 @@ class TestDefaultPriorityWeightingLayerDialog(TestCase):
         layer_dialog.txt_name.setText(edit_name)
         layer_dialog.txt_description.setPlainText(edit_description)
         layer_dialog.map_layer_file_widget.setFilePath(self.pwl_path)
-        layer_dialog.accept()
+        layer_dialog.save()
 
         saved_pwl = layer_dialog.layer
         self.assertIsNotNone(saved_pwl)


### PR DESCRIPTION
This PR introduces functionality to add new default global PWLs and update existing ones through the settings interface.

**Key Features**

- Add default PWLs
- Administrative users can add new global layers to the system.
- Each layer includes metadata such as name, description, version, and license.
- Update default PWLs
- Allows modification of metadata and file for existing layers.

![ScreenRecording2025-05-19094026-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/384c4ec2-27b5-41a9-9335-b59988def07d)

