### PR TITLE
Add Raster Normalized Validator

### DIFF
--- a/src/cplus_plugin/lib/validation/configs.py
+++ b/src/cplus_plugin/lib/validation/configs.py
@@ -60,3 +60,11 @@ no_data_validation_config = RuleConfiguration(
     "NoData Value Check",
     tr("Use the 'Fill nodata' or 'Translate' tool to change the NoData value"),
 )
+
+# Normalized values (0 - 1) validation
+normalized_validation_config = RuleConfiguration(
+    ValidationCategory.ERROR,
+    tr("Raster values must be normalized between 0 - 1"),
+    "Normalization Check",
+    tr("Use the raster calculator to normalize the raster values"),
+)

--- a/src/cplus_plugin/models/validation.py
+++ b/src/cplus_plugin/models/validation.py
@@ -18,6 +18,7 @@ class RuleType(IntEnum):
     RESOLUTION = 3
     CARBON_RESOLUTION = 4
     PROJECTED_CRS = 5
+    NORMALIZED = 6
 
 
 class ValidationCategory(IntEnum):


### PR DESCRIPTION
This addresses #642.

This is new validator that checks if the input NCS pathways have been normalized (i.e. raster values between 0 and 1), and notifies accordingly in the validation inspector window.