### PR TITLE
Show the default PWLS table

### DIFF
--- a/src/cplus_plugin/api/request.py
+++ b/src/cplus_plugin/api/request.py
@@ -190,6 +190,9 @@ class CplusApiUrl:
         else:
             return BASE_API_URL
 
+    def user_profile(self):
+        return f"{self.base_url}/user/me"
+
     def layer_detail(self, layer_uuid) -> str:
         """Cplus API URL to get layer detail.
 
@@ -782,6 +785,14 @@ class CplusApiRequest:
         self._api_token = access_token
         self.token_exp = datetime.datetime.now() + datetime.timedelta(days=1)
         return access_token
+
+    def get_user_profile(self) -> dict:
+        """Request for getting user profile.
+        :return: User profile
+        :rtype: dict
+        """
+        result, _ = self.get(self.urls.user_profile())
+        return result
 
     def get_layer_detail(self, layer_uuid) -> dict:
         """Request for getting layer detail.

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -143,6 +143,7 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
         self.task = None
         self.processing_cancelled = False
         self.current_analysis_task = None
+        self.fetch_default_layer_task = None
 
         # Set icons for buttons
         help_icon = FileUtils.get_icon("mActionHelpContents_green.svg")
@@ -1133,8 +1134,8 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
         """Fetch default layer list from API."""
         if not self.has_trends_auth():
             return
-        task = FetchDefaultLayerTask()
-        QgsApplication.taskManager().addTask(task)
+        self.fetch_default_layer_task = FetchDefaultLayerTask()
+        QgsApplication.taskManager().addTask(self.fetch_default_layer_task)
 
     def update_scenario_list(self):
         """Fetches scenarios from plugin settings and updates the

--- a/src/cplus_plugin/gui/settings/cplus_options.py
+++ b/src/cplus_plugin/gui/settings/cplus_options.py
@@ -280,7 +280,9 @@ class DlgSettingsLogin(QtWidgets.QDialog, Ui_TrendsEarthDlgSettingsLogin):
             self.main_widget.fetch_default_layer_list()
 
             self.parent.enable_admin_components()
-            self.parent.refresh_default_layers_table()
+            self.main_widget.fetch_default_layer_task.task_finished.connect(
+                self.parent.refresh_default_layers_table
+            )
 
             self.main_widget.fetch_scenario_history_list()
 

--- a/src/cplus_plugin/gui/settings/cplus_options.py
+++ b/src/cplus_plugin/gui/settings/cplus_options.py
@@ -1589,8 +1589,9 @@ class CplusSettings(Ui_DlgSettings, QgsOptionsPageWidget):
             try:
                 # Fetch user profile using Cplus API
                 user = self.request.get_user_profile()
+                print(user)
                 # Currently allow only internal users to manage default PWLs
-                if user and user.get("Internal"):
+                if user and user.get("role") == "Internal":
                     self.btn_add_pwl.show()
                     self.btn_edit_pwl.show()
                     self.btn_delete_pwl.show()

--- a/src/cplus_plugin/gui/settings/cplus_options.py
+++ b/src/cplus_plugin/gui/settings/cplus_options.py
@@ -1589,7 +1589,6 @@ class CplusSettings(Ui_DlgSettings, QgsOptionsPageWidget):
             try:
                 # Fetch user profile using Cplus API
                 user = self.request.get_user_profile()
-                print(user)
                 # Currently allow only internal users to manage default PWLs
                 if user and user.get("role") == "Internal":
                     self.btn_add_pwl.show()

--- a/src/cplus_plugin/gui/settings/cplus_options.py
+++ b/src/cplus_plugin/gui/settings/cplus_options.py
@@ -235,6 +235,7 @@ class DlgSettingsLogin(QtWidgets.QDialog, Ui_TrendsEarthDlgSettingsLogin):
         self.ok = False
         self.trends_earth_api_client = api.APIClient(API_URL, TIMEOUT)
         self.main_widget = main_widget
+        self.parent = parent
 
     def showEvent(self, event):
         super().showEvent(event)
@@ -278,7 +279,7 @@ class DlgSettingsLogin(QtWidgets.QDialog, Ui_TrendsEarthDlgSettingsLogin):
             settings_manager.remove_default_layers()
             self.main_widget.fetch_default_layer_list()
             self.main_widget.fetch_scenario_history_list()
-            self.main_widget.enable_admin_components()
+            self.parent.enable_admin_components()
             self.ok = True
             self.close()
 
@@ -550,7 +551,9 @@ class CplusSettings(Ui_DlgSettings, QgsOptionsPageWidget):
 
         # Trends.Earth settings
         self.dlg_settings_register = DlgSettingsRegister()
-        self.dlg_settings_login = DlgSettingsLogin(main_widget=self.main_widget)
+        self.dlg_settings_login = DlgSettingsLogin(
+            parent=self, main_widget=self.main_widget
+        )
 
         self.pushButton_register.clicked.connect(self.register)
         self.pushButton_login.clicked.connect(self.login)
@@ -1560,16 +1563,16 @@ class CplusSettings(Ui_DlgSettings, QgsOptionsPageWidget):
 
     def enable_admin_components(self):
         user = self.trends_earth_api_client.get_user()
-        if user:
-            self.pwl_layers_box.show()
-        else:
-            self.pwl_layers_box.hide()
-
         # TODO: Check the role of the user. Show admin components based on roles
         # if user.get("role") == "USER":
-        self.btn_add_pwl.show()
-        self.btn_edit_pwl.show()
-        self.btn_delete_pwl.show()
+        if user:
+            self.btn_add_pwl.show()
+            self.btn_edit_pwl.show()
+            self.btn_delete_pwl.show()
+        else:
+            self.btn_add_pwl.hide()
+            self.btn_edit_pwl.hide()
+            self.btn_delete_pwl.hide()
 
 
 class CplusOptionsFactory(QgsOptionsWidgetFactory):

--- a/src/cplus_plugin/gui/settings/cplus_options.py
+++ b/src/cplus_plugin/gui/settings/cplus_options.py
@@ -278,8 +278,12 @@ class DlgSettingsLogin(QtWidgets.QDialog, Ui_TrendsEarthDlgSettingsLogin):
             settings_manager.delete_online_scenario()
             settings_manager.remove_default_layers()
             self.main_widget.fetch_default_layer_list()
-            self.main_widget.fetch_scenario_history_list()
+
             self.parent.enable_admin_components()
+            self.parent.refresh_default_layers_table()
+
+            self.main_widget.fetch_scenario_history_list()
+
             self.ok = True
             self.close()
 


### PR DESCRIPTION
This PR Fixes bug when enabling admin buttons for default PWL management

- Show empty default PWLS table without requiring authentication. Table is populated with list of PWLs for authenticated users.
- Show add/edit/delete buttons for internal users.

<table>
<tr>
<td>External users</td>
<td>Internal users</td>
</tr>
<tr>
<td>
<img width="686" alt="image" src="https://github.com/user-attachments/assets/0782313c-3b21-49c7-b3ef-d162a0bb59e1" />
</td>
<td>
<img width="820" alt="image" src="https://github.com/user-attachments/assets/44e1eec2-8451-485f-9912-3b02cb93ec85" />
</td>
</tr>
</table>