### PR TITLE
Improve UX for layer selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ cplus_scenario_output.*
 reports
 
 ext-libs/
+src/cplus_plugin/gui/settings/cplus_options.py
+.vscode
+.vscode-extensions

--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,5 @@ cplus_scenario_output.*
 reports
 
 ext-libs/
-src/cplus_plugin/gui/settings/cplus_options.py
 .vscode
 .vscode-extensions

--- a/src/cplus_plugin/gui/settings/cplus_options.py
+++ b/src/cplus_plugin/gui/settings/cplus_options.py
@@ -1251,6 +1251,17 @@ class CplusSettings(Ui_DlgSettings, QgsOptionsPageWidget):
         self.tbl_pwl_layers.sortByColumn(0, Qt.AscendingOrder)
         self.tbl_pwl_layers.setAlternatingRowColors(False)
         self.tbl_pwl_layers.setColumnHidden(0, True)  # Hide the column (ID)
+        # Set minimum height of the table to accommodate 10 rows or the number of rows, whichever is smaller
+        row_height = self.tbl_pwl_layers.verticalHeader().defaultSectionSize()
+        min_height = 10 * row_height
+        self.tbl_pwl_layers.setMinimumHeight(min_height)
+        # Resize the parent container to avoid scrollbars
+        self.pwl_layers_box.setMinimumHeight(
+            min_height
+            + self.tbl_pwl_layers.horizontalHeader().height()
+            + self.btn_add_mask.height()
+            + 20
+        )
 
     def refresh_default_layers_table(self):
         """Refresh the default layers table with updated data."""


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/39fb44d1-ee4f-4f10-80bf-d67837844071)

This improves the display of the PWL layers widget so it is by default the height of 10 rows and does not force the user to scroll when there are few layers loaded.