### PR TITLE
Fix Activity Layer Styling

### DIFF
--- a/src/cplus_plugin/tasks.py
+++ b/src/cplus_plugin/tasks.py
@@ -1769,7 +1769,7 @@ class ScenarioAnalysisTask(QgsTask):
         if self.processing_cancelled:
             return False
 
-        self.set_status_message(tr("Updating weighted activity values"))
+        self.set_status_message(tr("Updating activity values"))
 
         try:
             for activity in activities:
@@ -1821,7 +1821,7 @@ class ScenarioAnalysisTask(QgsTask):
 
                 self.log_message(
                     f"Used parameters for "
-                    f"updates on the weighted activities: {alg_params} \n"
+                    f"updates on the cleaned activities: {alg_params} \n"
                 )
 
                 feedback = QgsProcessingFeedback()


### PR DESCRIPTION
This resolves a styling issue affecting activity layers with identical min/max values, where the single pseudocolor renderer cannot be applied. In such cases, a unique or palette-based value is used instead.

![image](https://github.com/user-attachments/assets/0690f1b9-1a08-4724-a385-f818eecb0308)

Additionally, the PR includes a minor update to the message displayed in the progress dialog during scenario analysis.