### PR TITLE
Enable grouping online pathways by sources in Pathway Editor

### DIFF
--- a/src/cplus_plugin/api/request.py
+++ b/src/cplus_plugin/api/request.py
@@ -16,7 +16,7 @@ from qgis.core import (
     QgsProcessingFeedback,
 )
 
-from ..models.base import Scenario, SpatialExtent, Activity
+from ..models.base import Scenario, SpatialExtent, Activity, LayerSource
 from ..conf import settings_manager, Settings
 from ..definitions.defaults import BASE_API_URL
 from ..trends_earth import auth
@@ -1064,12 +1064,10 @@ class CplusApiRequest:
             source = layer.get("source", "")
             if not source:
                 # If source is not provided, extract source from metadata name
-                if metadata.get("name", "").startswith("CPLUS:"):
-                    source = "cplus"
-                elif metadata.get("name", "").startswith("Naturebase:"):
-                    source = "naturebase"
+                if metadata.get("name", "").startswith("Naturebase:"):
+                    source = LayerSource.NATUREBASE.value
                 else:
-                    source = "cplus"
+                    source = LayerSource.CPLUS.value
 
             out_layer = {
                 "type": component_type,

--- a/src/cplus_plugin/api/request.py
+++ b/src/cplus_plugin/api/request.py
@@ -1060,18 +1060,30 @@ class CplusApiRequest:
         data = {}
         for layer in result:
             component_type = layer.get("component_type", "")
+            metadata = layer.get("metadata", {})
+            source = layer.get("source", "")
+            if not source:
+                # If source is not provided, extract source from metadata name
+                if metadata.get("name", "").startswith("CPLUS:"):
+                    source = "cplus"
+                elif metadata.get("name", "").startswith("Naturebase:"):
+                    source = "naturebase"
+                else:
+                    source = "cplus"
+
             out_layer = {
                 "type": component_type,
                 "layer_uuid": layer.get("uuid"),
                 "name": layer.get("filename"),
                 "size": layer.get("size"),
                 "layer_type": layer.get("layer_type"),
-                "metadata": layer.get("metadata", {}),
+                "metadata": metadata,
                 "filename": layer.get("filename"),
                 "created_on": layer.get("created_on"),
                 "url": layer.get("url"),
                 "version": layer.get("version"),
                 "license": layer.get("license"),
+                "source": source,
             }
             if component_type in data:
                 data[component_type].append(out_layer)

--- a/src/cplus_plugin/gui/ncs_pathway_editor_dialog.py
+++ b/src/cplus_plugin/gui/ncs_pathway_editor_dialog.py
@@ -76,7 +76,7 @@ class NcsPathwayEditorDialog(QtWidgets.QDialog, WidgetUi):
             elif source == LayerSource.NATUREBASE.value.lower():
                 self.naturebase_list.append(pathway)
 
-        items = sorted([p["metadata"].get("name", p["name"]) for p in self.cplus_list])
+        items = sorted([p["name"] for p in self.cplus_list])
         self.cbo_default_layer.addItems(items)
         self.cbo_default_layer.setCurrentIndex(0)
         self.cbo_default_layer.currentIndexChanged.connect(
@@ -354,9 +354,7 @@ class NcsPathwayEditorDialog(QtWidgets.QDialog, WidgetUi):
         if layer_name == "":
             return {}
         pathways = settings_manager.get_default_layers("ncs_pathway")
-        layer = [
-            p for p in pathways if p["metadata"].get("name", p["name"]) == layer_name
-        ]
+        layer = [p for p in pathways if p["name"] == layer_name]
         return layer[0] if layer else {}
 
     def open_help(self, activated: bool):
@@ -416,13 +414,9 @@ class NcsPathwayEditorDialog(QtWidgets.QDialog, WidgetUi):
         """Event raised when online layer source selection is changed."""
         source = self.cbo_default_layer_source.currentText()
         if source.lower() == LayerSource.CPLUS.value.lower():
-            items = sorted(
-                [p["metadata"].get("name", p["name"]) for p in self.cplus_list]
-            )
+            items = sorted([p["name"] for p in self.cplus_list])
         elif source == LayerSource.NATUREBASE.value:
-            items = sorted(
-                [p["metadata"].get("name", p["name"]) for p in self.naturebase_list]
-            )
+            items = sorted([p["name"] for p in self.naturebase_list])
         self.cbo_default_layer.clear()
         self.cbo_default_layer.addItem("")
         self.cbo_default_layer.addItems(items)

--- a/src/cplus_plugin/models/base.py
+++ b/src/cplus_plugin/models/base.py
@@ -649,3 +649,10 @@ class DataSourceType(IntEnum):
             1: DataSourceType.ONLINE,
             -1: DataSourceType.UNDEFINED,
         }[int_enum]
+
+
+class LayerSource(Enum):
+    """Specify if a layer source is cplus or naturebase."""
+
+    CPLUS = "CPLUS"
+    NATUREBASE = "Naturebase"

--- a/src/cplus_plugin/ui/ncs_pathway_editor_dialog.ui
+++ b/src/cplus_plugin/ui/ncs_pathway_editor_dialog.ui
@@ -229,6 +229,9 @@
            <number>2</number>
           </property>
           <item row="0" column="0">
+           <widget class="QComboBox" name="cbo_default_layer_source"/>
+          </item>
+          <item row="0" column="1" colspan="2">
            <widget class="QComboBox" name="cbo_default_layer"/>
           </item>
          </layout>


### PR DESCRIPTION
Fixes https://github.com/ConservationInternational/cplus-plugin/issues/695

This PR supports grouping pathways by their sources in the NCS Pathway Editor.

<table>
<tr>
<td>Old</td>
<td>New</td>
</tr>
<tr>
<td>
<img width="337" alt="image" src="https://github.com/user-attachments/assets/553f72ac-d16b-4876-b229-1c2c2fdea43a" />
</td>
<td>
<img width="385" alt="image" src="https://github.com/user-attachments/assets/abc2c39b-ad8d-4f88-8cd0-9a8a28e49206" />
</td>
</tr>