### PR TITLE
Remove the auto populate behavior of the AoI combobox

### DIFF
--- a/src/cplus_plugin/conf.py
+++ b/src/cplus_plugin/conf.py
@@ -419,6 +419,7 @@ class SettingsManager(QtCore.QObject):
             )
             settings.setValue("clip_to_studyarea", scenario_settings.clip_to_studyarea)
             settings.setValue("studyarea_path", scenario_settings.studyarea_path)
+            settings.setValue("crs", scenario_settings.crs)
 
     def save_scenario_extent(self, key, extent):
         """Saves the scenario extent into plugin settings

--- a/src/cplus_plugin/conf.py
+++ b/src/cplus_plugin/conf.py
@@ -193,6 +193,7 @@ class Settings(enum.Enum):
     SCENARIO_NAME = "scenario_name"
     SCENARIO_DESCRIPTION = "scenario_description"
     SCENARIO_EXTENT = "scenario_extent"
+    SCENARIO_EXTENT_CRS = "scenario_extent_crs"
     SCENARIO_CRS = "scenario_crs"
     SCENARIO_IMPACT_MATRIX = "scenario_impact_matrix"
 

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -573,7 +573,6 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
         settings_manager.set_value(Settings.LAST_DATA_DIR, os.path.dirname(layer_path))
         settings_manager.set_value(Settings.STUDYAREA_PATH, layer_path)
 
-        self.set_crs_from_layer(layer)
         self.save_scenario()
 
     def _on_studyarea_layer_changed(self, layer):
@@ -584,7 +583,6 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
             self._aoi_layer = layer
             settings_manager.set_value(Settings.STUDYAREA_PATH, layer.source())
 
-            self.set_crs_from_layer(layer)
             self.save_scenario()
 
     def can_clip_to_studyarea(self) -> bool:
@@ -607,21 +605,6 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
         if self._aoi_layer:
             return self._aoi_layer.source()
         return ""
-
-    def set_crs_from_layer(self, layer):
-        """Set the CRS of the CRS selector component from a layer
-        if the selector CRS is None or Invalid or IsGeographic
-        and the layer CRS is not None and IsValid and is not Geographic
-        """
-        selected_crs = self.crs_selector.crs()
-        if (
-            (selected_crs is None)
-            or (not selected_crs.isValid())
-            or (selected_crs.isGeographic())
-        ):
-            layer_crs = layer.crs()
-            if (layer_crs and layer_crs.isValid()) and (not layer_crs.isGeographic()):
-                self.crs_selector.setCrs(layer_crs)
 
     def priority_groups_update(self, target_item, selected_items):
         """Updates the priority groups list item with the passed
@@ -663,36 +646,27 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
         scenario_name = self.scenario_name.text()
         scenario_description = self.scenario_description.text()
 
-        self.extent_box.setOutputCrs(self.crs_selector.crs())
-        aoi_layer = QgsVectorLayer(self.get_studyarea_path(), "studyarea_path")
-        if (
-            self._aoi_source_group.checkedId() == AreaOfInterestSource.LAYER.value
-            and aoi_layer.isValid()
-        ):
-            aoi_layer_extent = aoi_layer.extent()
-            aoi_layer_crs = aoi_layer.crs()
-            extent = self.transform_extent(
-                aoi_layer_extent, aoi_layer_crs, self.crs_selector.crs()
+        if self.can_clip_to_studyarea():
+            settings_manager.set_value(
+                Settings.STUDYAREA_PATH, self.get_studyarea_path()
             )
         else:
             extent = self.extent_box.outputExtent()
-
-        extent_box = [
-            extent.xMinimum(),
-            extent.xMaximum(),
-            extent.yMinimum(),
-            extent.yMaximum(),
-        ]
+            extent_box = [
+                extent.xMinimum(),
+                extent.xMaximum(),
+                extent.yMinimum(),
+                extent.yMaximum(),
+            ]
+            settings_manager.set_value(Settings.SCENARIO_EXTENT, extent_box)
 
         settings_manager.set_value(Settings.SCENARIO_NAME, scenario_name)
         settings_manager.set_value(Settings.SCENARIO_DESCRIPTION, scenario_description)
-        settings_manager.set_value(Settings.SCENARIO_EXTENT, extent_box)
 
         settings_manager.set_value(
             Settings.SCENARIO_CRS, self.crs_selector.crs().authid()
         )
 
-        settings_manager.set_value(Settings.STUDYAREA_PATH, self.get_studyarea_path())
         settings_manager.set_value(
             Settings.CLIP_TO_STUDYAREA, self.can_clip_to_studyarea()
         )

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -653,6 +653,9 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
                 extent.yMaximum(),
             ]
             settings_manager.set_value(Settings.SCENARIO_EXTENT, extent_box)
+            settings_manager.set_value(
+                Settings.SCENARIO_EXTENT_CRS, self.extent_box.outputCrs().authid()
+            )
 
         settings_manager.set_value(Settings.SCENARIO_NAME, scenario_name)
         settings_manager.set_value(Settings.SCENARIO_DESCRIPTION, scenario_description)
@@ -690,10 +693,19 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
             extent_rectangle = QgsRectangle(
                 float(extent[0]), float(extent[2]), float(extent[1]), float(extent[3])
             )
+
+            extent_crs = QgsCoordinateReferenceSystem(
+                settings_manager.get_value(
+                    Settings.SCENARIO_EXTENT_CRS, f"EPSG:{DEFAULT_CRS_ID}"
+                )
+            )
+            extent_crs = (
+                extent_crs if extent_crs.isValid() else self.extent_box.outputCrs()
+            )
+
             self.extent_box.setOutputExtentFromUser(
                 extent_rectangle,
-                self.extent_box.outputCrs()
-                or QgsCoordinateReferenceSystem.fromEpsgId(DEFAULT_CRS_ID),
+                extent_crs,
             )
 
         if studyarea_path:

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -2682,6 +2682,7 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
         )
 
         self.cbo_studyarea.layerChanged.connect(self._on_studyarea_layer_changed)
+        self.cbo_studyarea.setAllowEmptyLayer(True, tr("<Select layer>"))
         self.cbo_studyarea.setFilters(QgsMapLayerProxyModel.PolygonLayer)
 
         self.studyarea_layer_file_widget.setToolTip(

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -518,12 +518,6 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
     def on_crs_changed(self):
         self.message_bar.clearWidgets()
         current_crs = self.crs_selector.crs()
-        self.extent_box.setOutputCrs(current_crs)
-
-        self.extent_box.setOutputExtentFromUser(
-            self.extent_box.outputExtent(),
-            current_crs,
-        )
 
         if current_crs.isValid():
             authid = current_crs.authid()

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -674,7 +674,9 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
         scenario_description = settings_manager.get_value(Settings.SCENARIO_DESCRIPTION)
         extent = settings_manager.get_value(Settings.SCENARIO_EXTENT)
         studyarea_path = settings_manager.get_value(Settings.STUDYAREA_PATH)
-        clip_to_studyarea = settings_manager.get_value(Settings.CLIP_TO_STUDYAREA)
+        clip_to_studyarea = settings_manager.get_value(
+            Settings.CLIP_TO_STUDYAREA, default=False, setting_type=bool
+        )
         crs = QgsCoordinateReferenceSystem(
             settings_manager.get_value(Settings.SCENARIO_CRS, f"EPSG:{DEFAULT_CRS_ID}")
         )
@@ -719,6 +721,7 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
         else:
             self.rb_extent.setChecked(True)
             self.on_aoi_source_changed(1, True)
+        print("Restored scenario", clip_to_studyarea, studyarea_path)
 
     def initialize_priority_layers(self):
         """Prepares the priority weighted layers UI with the defaults.

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -698,6 +698,8 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
 
         if studyarea_path:
             self._aoi_layer = QgsVectorLayer(studyarea_path, Path(studyarea_path).stem)
+            if self._aoi_layer.isValid():
+                self.studyarea_layer_file_widget.setFilePath(studyarea_path)
 
         if clip_to_studyarea:
             self.on_aoi_source_changed(0, True)

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -692,9 +692,9 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
             )
             self.extent_box.setOutputExtentFromUser(
                 extent_rectangle,
-                crs,
+                self.extent_box.outputCrs()
+                or QgsCoordinateReferenceSystem.fromEpsgId(DEFAULT_CRS_ID),
             )
-            self.extent_box.setOutputCrs(crs)
 
         if studyarea_path:
             self._aoi_layer = QgsVectorLayer(studyarea_path, Path(studyarea_path).stem)

--- a/src/cplus_plugin/gui/scenario_dialog.py
+++ b/src/cplus_plugin/gui/scenario_dialog.py
@@ -58,12 +58,11 @@ class ScenarioDialog(QtWidgets.QDialog, DialogUi):
             # Area of Interest
             self.rb_studyarea.setEnabled(False)
             self.rb_extent.setEnabled(False)
-            self.cbo_studyarea.setEnabled(False)
+
             if self.scenario.studyarea_path and os.path.exists(
                 self.scenario.studyarea_path
             ):
-                self._add_layer_path(self.scenario.studyarea_path)
-
+                self.scenario_studyarea.setText(self.scenario.studyarea_path)
             if self.scenario.clip_to_studyarea:
                 self.on_aoi_source_changed(0, True)
                 self.rb_studyarea.setChecked(True)
@@ -71,15 +70,13 @@ class ScenarioDialog(QtWidgets.QDialog, DialogUi):
                 self.rb_extent.setChecked(True)
                 self.on_aoi_source_changed(1, True)
 
-            # CRS Selector
-            crs = QgsCoordinateReferenceSystem.fromEpsgId(DEFAULT_CRS_ID)
+            # CRS
             if self.scenario.extent.crs:
-                crs = QgsCoordinateReferenceSystem(self.scenario.extent.crs)
+                self.crs_text.setText(str(self.scenario.extent.crs))
+            else:
+                self.crs_text.setText(str(DEFAULT_CRS_ID))
 
-            if crs.isValid():
-                self.crs_selector.setCrs(crs)
-
-            self.crs_selector.setEnabled(False)
+            crs = QgsCoordinateReferenceSystem(self.crs_text.text())
 
             self.extent_box.setOutputCrs(crs)
             map_canvas = iface.mapCanvas()
@@ -103,24 +100,6 @@ class ScenarioDialog(QtWidgets.QDialog, DialogUi):
                     default_extent,
                     crs,
                 )
-
-    def _add_layer_path(self, layer_path: str):
-        """Select or add layer path to the map layer combobox."""
-        matching_index = -1
-        num_layers = self.cbo_studyarea.count()
-        for index in range(num_layers):
-            layer = self.cbo_studyarea.layer(index)
-            if layer is None:
-                continue
-            if os.path.normpath(layer.source()) == os.path.normpath(layer_path):
-                matching_index = index
-                break
-
-        if matching_index == -1:
-            self.cbo_studyarea.setAdditionalItems([layer_path])
-            self.cbo_studyarea.setCurrentIndex(num_layers)
-        else:
-            self.cbo_studyarea.setCurrentIndex(matching_index)
 
     def on_aoi_source_changed(self, button_id: int, toggled: bool):
         """Slot raised when the area of interest source button group has

--- a/src/cplus_plugin/models/base.py
+++ b/src/cplus_plugin/models/base.py
@@ -618,6 +618,7 @@ class Scenario(BaseModelComponent):
     server_uuid: UUID = None
     clip_to_studyarea: bool = False
     studyarea_path: str = None
+    crs: str = None
 
 
 @dataclasses.dataclass

--- a/src/cplus_plugin/ui/qgis_cplus_main_dockwidget.ui
+++ b/src/cplus_plugin/ui/qgis_cplus_main_dockwidget.ui
@@ -166,27 +166,18 @@
               <number>0</number>
              </property>
              <widget class="QWidget" name="pg_local">
-              <layout class="QGridLayout" name="gridLayout_2">
-               <property name="leftMargin">
-                <number>2</number>
-               </property>
-               <property name="topMargin">
-                <number>2</number>
-               </property>
-               <property name="rightMargin">
-                <number>2</number>
-               </property>
-               <property name="bottomMargin">
-                <number>2</number>
-               </property>
-               <item row="0" column="0" alignment="Qt::AlignTop">
-                <widget class="QgsMapLayerComboBox" name="cbo_studyarea">                 
+              <layout class="QHBoxLayout" name="horizontalLayout">
+               <item alignment="Qt::AlignTop">
+                <widget class="QgsFileWidget" name="studyarea_layer_file_widget">
+                 <property name="toolTip">
+                  <string>Select the study area layer from the local filesystem.</string>
+                 </property>
                 </widget>
                </item>
-               <item row="0" column="1" alignment="Qt::AlignTop">
-                <widget class="QToolButton" name="btn_choose_studyarea_file">
-                 <property name="text">
-                  <string>...</string>
+               <item alignment="Qt::AlignTop">
+                <widget class="QgsMapLayerComboBox" name="cbo_studyarea">
+                 <property name="toolTip">
+                  <string>Select study area layer from the current QGIS map layers.</string>
                  </property>
                 </widget>
                </item>
@@ -299,7 +290,7 @@
             </property>
             <property name="icon">
              <iconset>
-              <normaloff>../../../../../../../resources/cplus_right_arrow.svg</normaloff>../../../../../../../resources/cplus_right_arrow.svg</iconset>
+              <normaloff>../../../../../../resources/cplus_right_arrow.svg</normaloff>../../../../../../resources/cplus_right_arrow.svg</iconset>
             </property>
            </widget>
           </item>
@@ -313,7 +304,7 @@
             </property>
             <property name="icon">
              <iconset>
-              <normaloff>../../../../../../../resources/cplus_left_arrow.svg</normaloff>../../../../../../../resources/cplus_left_arrow.svg</iconset>
+              <normaloff>../../../../../../resources/cplus_left_arrow.svg</normaloff>../../../../../../resources/cplus_left_arrow.svg</iconset>
             </property>
            </widget>
           </item>
@@ -889,6 +880,11 @@
    <extends>QgsCollapsibleGroupBox</extends>
    <header>qgsextentgroupbox.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsFileWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfilewidget.h</header>
   </customwidget>
   <customwidget>
    <class>QgsMapLayerComboBox</class>

--- a/src/cplus_plugin/ui/scenario_dialog.ui
+++ b/src/cplus_plugin/ui/scenario_dialog.ui
@@ -157,86 +157,79 @@
      </property>
     </widget>
    </item>
-   <item>
+   <item alignment="Qt::AlignTop">
     <widget class="QGroupBox" name="group_box_aoi">
-      <property name="title">
-        <string>Area of Interest</string>
-      </property>
-      <layout class="QGridLayout" name="gridLayout_3">
-        <item row="0" column="0">
-          <widget class="QRadioButton" name="rb_studyarea">
-            <property name="text">
-              <string>Layer</string>
-            </property>
-          </widget>
-        </item>
-        <item row="0" column="1">
-          <widget class="QRadioButton" name="rb_extent">
-            <property name="text">
-              <string>Extent</string>
-            </property>
-          </widget>
-        </item>
-        <item row="1" column="0" colspan="2">
-          <widget class="QStackedWidget" name="studyarea_stacked_widget">
-            <property name="frameShape">
-              <enum>QFrame::NoFrame</enum>
-            </property>
-            <property name="currentIndex">
-              <number>0</number>
-            </property>
-            <widget class="QWidget" name="pg_local">
-              <layout class="QGridLayout" name="gridLayout_2">
-                <property name="leftMargin">
-                  <number>2</number>
-                </property>
-                <property name="topMargin">
-                  <number>2</number>
-                </property>
-                <property name="rightMargin">
-                  <number>2</number>
-                </property>
-                <property name="bottomMargin">
-                  <number>2</number>
-                </property>
-                <item row="0" column="0" alignment="Qt::AlignTop">
-                  <widget class="QgsMapLayerComboBox" name="cbo_studyarea">                 
-                  </widget>
-                </item>
-                <item row="0" column="1" alignment="Qt::AlignTop">
-                  <widget class="QToolButton" name="btn_choose_studyarea_file">
-                  <property name="text">
-                    <string>...</string>
-                  </property>
-                  </widget>
-                </item>
-              </layout>
-            </widget>
-            <widget class="QgsExtentGroupBox" name="extent_box">
-              <property name="title">
-                <string>Area of interest (Study Area)</string>
-              </property>
-              <property name="checkable">
-                <bool>true</bool>
-              </property>
-              <property name="collapsed">
-                <bool>false</bool>
-              </property>
-            </widget>
-          </widget>
-        </item>
-      </layout>
+     <property name="title">
+      <string>Area of Interest</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="0">
+       <widget class="QRadioButton" name="rb_studyarea">
+        <property name="text">
+         <string>Layer</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QRadioButton" name="rb_extent">
+        <property name="text">
+         <string>Extent</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2" alignment="Qt::AlignTop">
+       <widget class="QStackedWidget" name="studyarea_stacked_widget">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::NoFrame</enum>
+        </property>
+        <property name="currentIndex">
+         <number>1</number>
+        </property>
+        <widget class="QLineEdit" name="scenario_studyarea">
+         <property name="toolTip">
+          <string>Path to the study area layer. </string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+         <property name="readOnly">
+          <bool>true</bool>
+         </property>
+        </widget>
+        <widget class="QgsExtentGroupBox" name="extent_box">
+         <property name="title">
+          <string>Area of interest (Study Area)</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="collapsed">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>
     <widget class="QLabel" name="lblCrsdescription">
-      <property name="text">
-        <string>Scenario CRS for analysis (Must be projected CRS)</string>
-      </property>
+     <property name="text">
+      <string>Scenario CRS for analysis (Must be projected CRS)</string>
+     </property>
     </widget>
    </item>
    <item>
-    <widget class="QgsProjectionSelectionWidget" name="crs_selector" native="true"/>
+    <widget class="QLineEdit" name="crs_text"/>
    </item>
    <item>
     <spacer name="verticalSpacer">
@@ -264,18 +257,6 @@
    <class>QgsExtentGroupBox</class>
    <extends>QgsCollapsibleGroupBox</extends>
    <header>qgsextentgroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsMapLayerComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgsmaplayercombobox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsProjectionSelectionWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsprojectionselectionwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
Fixes #753 #754 

This PR:
- removes the auto populate behavior of the area of interest layer selection combobox
- retains the last selected option when choosing to pick the area of interest from a layer of user defined extent.


![ScreenRecording2025-10-06235835-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/2c49d66c-9d29-425b-b327-2cec0aa9b886)
